### PR TITLE
Remove specific konnector slug handling

### DIFF
--- a/src/ducks/apps/components/ApplicationRouting.jsx
+++ b/src/ducks/apps/components/ApplicationRouting.jsx
@@ -7,7 +7,7 @@ import UninstallModal from './UninstallModal'
 import InstallModal from './InstallModal'
 import ApplicationPage from './ApplicationPage'
 
-import { APP_TYPE, _getKonnectorStackSlug } from 'ducks/apps'
+import { APP_TYPE } from 'ducks/apps'
 
 export class ApplicationRouting extends Component {
   render () {
@@ -85,7 +85,7 @@ export class ApplicationRouting extends Component {
                 return (<IntentModal
                   action='CREATE'
                   doctype='io.cozy.accounts'
-                  options={{ slug: _getKonnectorStackSlug(appSlug) }}
+                  options={{ slug: appSlug }}
                   dismissAction={goToApp}
                   onComplete={goToApp}
                 />)

--- a/test/ducks/apps/components/__snapshots__/applicationRouting.spec.js.snap
+++ b/test/ducks/apps/components/__snapshots__/applicationRouting.spec.js.snap
@@ -85,7 +85,7 @@ exports[`ApplicationRouting component with IntentModal should handle correctly i
   onComplete={[Function]}
   options={
     Object {
-      "slug": "trinlane",
+      "slug": "konnector-trinlane",
     }
   }
 />


### PR DESCRIPTION
Previously, we was adding `konnector-` before konnectors slug for the registry and remove it before installing in the cozy-stack.
Now we remove this specific behaviour.