### PR TITLE
enhancement: Better IntentHandler, ready to use in any app

### DIFF
--- a/src/ducks/components/intents/IntentHandler.jsx
+++ b/src/ducks/components/intents/IntentHandler.jsx
@@ -1,7 +1,6 @@
-import React, { Component } from 'react'
+import React, { Children, Component } from 'react'
 import { translate } from 'cozy-ui/react/I18n'
 
-import InstallAppIntent from './InstallAppIntent'
 import Spinner from 'cozy-ui/react/Spinner'
 
 class IntentHandler extends Component {
@@ -37,9 +36,13 @@ class IntentHandler extends Component {
   }
 
   render() {
-    const { appData, t } = this.props
+    const { appData, children, t } = this.props
     const { error, service, status } = this.state
-
+    const intent = service && service.getIntent()
+    const child = intent && Children.toArray(children).find(child => {
+      const { action, type } = child.props
+      return action === intent.action && type === intent.type
+    })
     return (
       <div className="coz-intent">
         {status === 'creating' && <Spinner size="xxlarge" />}
@@ -49,16 +52,16 @@ class IntentHandler extends Component {
             <p>{error.message}</p>
           </div>
         )}
-        {status === 'created' && (
+        {child && (
           // In the future, we may switch here between available intents
-          <InstallAppIntent
-            appData={appData}
-            data={service.getData()}
-            intent={service.getIntent()}
-            onCancel={() => service.cancel()}
-            onError={error => service.throw(error)}
-            onTerminate={app => service.terminate(app)}
-          />
+          React.cloneElement(child, {
+            appData: appData,
+            data: service.getData(),
+            intent: service.getIntent(),
+            onCancel: () => service.cancel(),
+            onError: error => service.throw(error),
+            onTerminate: app => service.terminate(app)
+          })
         )}
       </div>
     )

--- a/src/targets/intents/index.jsx
+++ b/src/targets/intents/index.jsx
@@ -10,6 +10,7 @@ import store from 'lib/store'
 
 import I18n from 'cozy-ui/react/I18n'
 import IntentHandler from '../../ducks/components/intents/IntentHandler'
+import InstallAppIntent from '../../ducks/components/intents/InstallAppIntent'
 
 // import 'styles/intents.styl'
 
@@ -31,10 +32,9 @@ document.addEventListener('DOMContentLoaded', () => {
       dictRequire={lang => require(`../../locales/${lang}`)}
     >
       <Provider store={store}>
-        <IntentHandler
-          appData={appData}
-          intents={cozy.client.intents}
-        />
+        <IntentHandler appData={appData} intents={cozy.client.intents}>
+          <InstallAppIntent action="INSTALL" type="io.cozy.apps" />
+        </IntentHandler>
       </Provider>
     </I18n>,
     document.querySelector('[role=application]')


### PR DESCRIPTION
An example which speaks by itself:

```jsx
<IntentHandler appData={appData} intents={cozy.client.intents}>
  <InstallAppIntent action="INSTALL" type="io.cozy.apps" />
</IntentHandler>
```