### PR TITLE
Remove Inc replacing for Cozy developer name

### DIFF
--- a/src/ducks/apps/components/ApplicationPage/Details.jsx
+++ b/src/ducks/apps/components/ApplicationPage/Details.jsx
@@ -110,10 +110,7 @@ export class Details extends Component {
       categories &&
       !!categories.length &&
       categories.map(c => t(`app_categories.${c}`))
-    const developerName =
-      developer && developer.name === 'Cozy'
-        ? 'Cozy Cloud Inc.'
-        : developer.name
+    const developerName = developer && developer.name
     const shortVersion = version && version.match(/^(\d+\.\d+\.\d+)-.*$/)
     const displayedVersion =
       (shortVersion && shortVersion.length && shortVersion[1]) || version

--- a/src/ducks/components/SmallAppItem.jsx
+++ b/src/ducks/components/SmallAppItem.jsx
@@ -56,9 +56,7 @@ export const SmallAppItem = ({
           <h4 className="sto-small-app-item-title">
             {namePrefix ? `${namePrefix} ${name}` : name}
           </h4>
-          <p className="sto-small-app-item-detail">
-            {developer.name === 'Cozy' ? 'Cozy Cloud Inc.' : developer.name}
-          </p>
+          <p className="sto-small-app-item-detail">{developer.name}</p>
         </div>
         <div className="sto-small-app-item-buttons">
           {installed ? (

--- a/test/components/__snapshots__/smallAppItem.spec.js.snap
+++ b/test/components/__snapshots__/smallAppItem.spec.js.snap
@@ -28,7 +28,7 @@ exports[`SmallAppItem component should be rendered correctly an app 1`] = `
       <p
         className="sto-small-app-item-detail"
       >
-        Cozy Cloud Inc.
+        Cozy
       </p>
     </div>
     <div

--- a/test/ducks/apps/components/applicationPage/__snapshots__/details.spec.js.snap
+++ b/test/ducks/apps/components/applicationPage/__snapshots__/details.spec.js.snap
@@ -215,7 +215,7 @@ Enjoy features to grab your data in you Cozy :tada:"
         className="sto-app-developer-infos"
       >
         <span>
-          Cozy Cloud Inc.
+          Cozy
         </span>
         <a
           className="sto-app-developer-link"
@@ -306,7 +306,7 @@ exports[`ApplicationPage details component should be rendered correctly with pro
         className="sto-app-developer-infos"
       >
         <span>
-          Cozy Cloud Inc.
+          Cozy
         </span>
         <a
           className="sto-app-developer-link"


### PR DESCRIPTION
If the developer name was `Cozy` it was automatically replaced by `Cozy Cloud Inc`, this behaviour is now completely removed to just displayed the developer name provided by the application manifest.