### PR TITLE
Use grayscale for doctype icons

### DIFF
--- a/src/styles/permissions.css
+++ b/src/styles/permissions.css
@@ -63,6 +63,10 @@
   background-position: top center;
   background-repeat: no-repeat;
   background-size: contain;
+  /* grayscale */
+  -webkit-filter: grayscale(100%);
+  filter: grayscale(100%);
+  filter: gray;
 }
 
 .sto-perm-title[data-doctype^="io.cozy.settings"]:before {


### PR DESCRIPTION
<img width="513" alt="screen shot 2018-05-31 at 16 00 09" src="https://user-images.githubusercontent.com/10224453/40786624-c29c9b5c-64eb-11e8-8bbd-6f67a6d80403.png">
