### PR TITLE
Add Intent Redirect handling

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -18,8 +18,8 @@
     {
       "action": "REDIRECT",
       "type": ["io.cozy.apps"],
-      "href": "/#/discover",
-      "data": ["type", "category", "doctype", "tag"]
+      "href": "/#/redirect",
+      "data": ["category", "doctype",  "slug", "tag", "type"]
     }, {
       "action": "INSTALL",
       "data": ["slug"],

--- a/src/ducks/components/App.jsx
+++ b/src/ducks/components/App.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import { Route, Switch, Redirect, withRouter } from 'react-router-dom'
 import { translate } from 'cozy-ui/react/I18n'
 
+import IntentRedirect from './intents/IntentRedirect'
 import Sidebar from './Sidebar'
 
 import { initApp, fetchIconsProgressively } from '../apps'
@@ -29,6 +30,7 @@ export class App extends Component {
         <Sidebar />
         <main className="app-content">
           <Switch>
+            <Route path="/redirect" component={IntentRedirect} />
             <Route path="/discover" component={Discover} />
             <Route path="/myapps" component={MyApplications} />
             <Redirect exact from="/" to="/discover" />

--- a/src/ducks/components/intents/IntentRedirect.jsx
+++ b/src/ducks/components/intents/IntentRedirect.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { Redirect } from 'react-router-dom'
+
+const IntentRedirect = ({ location }) => {
+  const queryString = !!location && location.search
+  const query =
+    queryString &&
+    queryString
+      .substring(1)
+      .split('&')
+      .reduce((accumulator, keyValue) => {
+        const splitted = keyValue.split('=')
+        accumulator[splitted[0]] = splitted[1] || true
+        return accumulator
+      }, {})
+
+  if (query.slug) return <Redirect to={`/discover/${query.slug}`} />
+  return <Redirect to={`/discover/${queryString}`} />
+}
+
+export default IntentRedirect

--- a/test/__snapshots__/app.spec.js.snap
+++ b/test/__snapshots__/app.spec.js.snap
@@ -14,6 +14,10 @@ exports[`App component only should be mounted correctly 1`] = `
     <Switch>
       <Route
         component={[Function]}
+        path="/redirect"
+      />
+      <Route
+        component={[Function]}
         path="/discover"
       />
       <Route


### PR DESCRIPTION
Pretty urgent for @drazik

This add an Intent redirection for apps with a slug, i.e. `/redirect?slug=trainline` will redirect to `/discover/trainline`. And update the manifest to handle this.

By default, redirection is still `/discover/<queryString>`