### PR TITLE
Improve app items grid (+ loading)

### DIFF
--- a/src/ducks/components/AppsLoading.jsx
+++ b/src/ducks/components/AppsLoading.jsx
@@ -1,41 +1,55 @@
 import React, { Component } from 'react'
+import withBreakpoints from 'cozy-ui/react/helpers/withBreakpoints'
 
 // subarray = sections, array of subsections
 // number = number of loading items per subsection
-const LOADING_SECTIONS = [[4, 4], [12, 8]]
+const LOADING_SECTIONS = [[5, 3, 9], [12, 8]]
 
-export const Placeholder = ({ width, height, withMargin }) => {
+export const Placeholder = ({ width, height, autoMargin }) => {
   const widthStyle = Array.isArray(width)
     ? `${Math.random() * (width[1] - width[0]) + width[0]}rem`
     : width
   const style = {
     width: widthStyle,
-    height,
-    margin: withMargin ? '.1rem 0' : '0'
+    height
   }
+  if (autoMargin) style.margin = 'auto'
   return <div className="sto-sections-placeholder" style={style} />
 }
 
-const LoadingAppsComponents = ({ count, subKey }) => {
+const LoadingAppsComponents = ({ count, subKey, breakpoints = {} }) => {
   let loadingApps = []
+  const { isMobile } = breakpoints
+  const iconSize = isMobile ? '2.5rem' : '3rem'
+  const widthMax = isMobile ? 5 : 8
   for (let i = 1; i <= count; i++) {
     loadingApps.push(
       <div className="sto-small-app-item" key={`${subKey}-${i}`}>
-        <div className="sto-small-app-item-icon">
-          <Placeholder width="4rem" height="4rem" />
+        <div className="sto-small-app-item-icon-wrapper">
+          <div className="sto-small-app-item-icon">
+            <Placeholder width={iconSize} height={iconSize} autoMargin />
+          </div>
         </div>
         <div className="sto-small-app-item-desc">
-          <div className="sto-small-app-item-text">
-            <h4 className="sto-small-app-item-title">
-              <Placeholder width={[4, 8]} height="1.1rem" withMargin />
-            </h4>
-            <p className="sto-small-app-item-detail">
-              <Placeholder width={[3, 5]} height=".75rem" withMargin />
+          <h4 className="sto-small-app-item-title">
+            <Placeholder
+              width={[4, widthMax]}
+              height={isMobile ? '.8rem' : '1.1rem'}
+              autoMargin
+            />
+          </h4>
+          <p className="sto-small-app-item-developer">
+            <Placeholder width={[4, widthMax]} height=".8rem" autoMargin />
+          </p>
+          {!!Math.round(Math.random()) && (
+            <p className="sto-small-app-item-status">
+              <Placeholder
+                width="4rem"
+                height={isMobile ? '.6rem' : '.8rem'}
+                autoMargin
+              />
             </p>
-          </div>
-          <div className="sto-small-app-item-buttons">
-            <Placeholder width="5rem" height="1.3rem" withMargin />
-          </div>
+          )}
         </div>
       </div>
     )
@@ -49,6 +63,7 @@ export class AppsLoading extends Component {
   }
 
   render() {
+    const { breakpoints } = this.props
     return (
       <div className="sto-sections --loading">
         {LOADING_SECTIONS.map((subsection, subIndex) => {
@@ -66,6 +81,7 @@ export class AppsLoading extends Component {
                     <LoadingAppsComponents
                       count={subsectionCount}
                       subKey={`${subIndex}-${i}`}
+                      breakpoints={breakpoints}
                     />
                   </div>
                 )
@@ -78,4 +94,4 @@ export class AppsLoading extends Component {
   }
 }
 
-export default AppsLoading
+export default withBreakpoints()(AppsLoading)

--- a/src/ducks/components/SmallAppItem.jsx
+++ b/src/ducks/components/SmallAppItem.jsx
@@ -4,8 +4,6 @@ import Icon from 'cozy-ui/react/Icon'
 import { translate } from 'cozy-ui/react/I18n'
 
 import defaultAppIcon from '../../assets/icons/icon-cube.svg'
-import { Link } from 'react-router-dom'
-import Button from 'cozy-ui/react/Button'
 import { Placeholder } from './AppsLoading'
 
 export const SmallAppItem = ({
@@ -17,15 +15,8 @@ export const SmallAppItem = ({
   name,
   namePrefix,
   installed,
-  onClick,
-  installedAppLink
+  onClick
 }) => {
-  const onShortcutAppButton = (e, link) => {
-    // prevent from opening parent SmallAppItem link
-    // which will lead to the application main page
-    e.stopPropagation()
-    if (link) window.location.assign(link)
-  }
   return (
     // HACK a11y
     // `onKeyDown={(e) => e.keyCode === 13 ? onClick() : null`
@@ -36,51 +27,37 @@ export const SmallAppItem = ({
       onClick={onClick}
       tabIndex={0}
     >
-      {iconToLoad ? (
-        <Placeholder width="4rem" height="4rem" />
-      ) : icon ? (
-        <img
-          src={icon}
-          alt={`${slug}-icon`}
-          width="64"
-          height="64"
-          className="sto-small-app-item-icon"
-        />
-      ) : (
-        <Icon
-          className="sto-small-app-item-icon--default blurry"
-          width="48"
-          height="64"
-          icon={defaultAppIcon}
-          color="#95999D"
-        />
-      )}
+      <div className="sto-small-app-item-icon-wrapper">
+        {iconToLoad ? (
+          <div className="sto-small-app-item-icon">
+            <Placeholder width="3rem" height="3rem" />
+          </div>
+        ) : icon ? (
+          <img
+            src={icon}
+            alt={`${slug}-icon`}
+            width="64"
+            height="64"
+            className="sto-small-app-item-icon"
+          />
+        ) : (
+          <Icon
+            className="sto-small-app-item-icon sto-small-app-item-icon--default blurry"
+            width="48"
+            height="64"
+            icon={defaultAppIcon}
+            color="#95999D"
+          />
+        )}
+      </div>
       <div className="sto-small-app-item-desc">
-        <div className="sto-small-app-item-text">
-          <h4 className="sto-small-app-item-title">
-            {namePrefix ? `${namePrefix} ${name}` : name}
-          </h4>
-          <p className="sto-small-app-item-detail">{developer.name}</p>
-        </div>
-        <div className="sto-small-app-item-buttons">
-          {installed ? (
-            <Button
-              onClick={e => onShortcutAppButton(e, installedAppLink)}
-              label={t('app_item.open')}
-              theme="secondary"
-              className="sto-small-app-item-button"
-              size="tiny"
-            />
-          ) : (
-            <Link
-              to={`/discover/${slug}/manage`}
-              onClick={e => onShortcutAppButton(e)}
-              className="c-btn c-btn--regular c-btn--tiny sto-small-app-item-button sto-small-app-item-button-install"
-            >
-              <span>{t('app_item.install')}</span>
-            </Link>
-          )}
-        </div>
+        <h4 className="sto-small-app-item-title">
+          {namePrefix ? `${namePrefix} ${name}` : name}
+        </h4>
+        <p className="sto-small-app-item-developer">{developer.name}</p>
+        {installed && (
+          <p className="sto-small-app-item-status">{t('app_item.installed')}</p>
+        )}
       </div>
     </div>
   )

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -108,8 +108,7 @@
   },
 
   "app_item": {
-    "open": "Open",
-    "install": "Install"
+    "installed": "Installed"
   },
 
   "app_categories": {

--- a/src/styles/loading.css
+++ b/src/styles/loading.css
@@ -41,3 +41,7 @@
 .sto-sections.--loading .sto-small-app-item {
   pointer-events:none;
 }
+
+.sto-sections.--loading .sto-small-app-item-icon-wrapper {
+  margin-bottom: .25rem;
+}

--- a/src/styles/sections.css
+++ b/src/styles/sections.css
@@ -16,3 +16,9 @@
   flex-wrap: wrap;
   justify-content: flex-start;
 }
+
+@media (min-width: 48rem) {
+  .sto-sections-title:first-child {
+    margin-top: 0;
+  }
+}

--- a/src/styles/smallAppItem.css
+++ b/src/styles/smallAppItem.css
@@ -1,137 +1,127 @@
 .sto-sections-list {
-  /* We differenciate the "real" margin from the "used" margin. The "used" margin
-  allow to use a little higher value for flex-basis calculation. Firefox
-  and Chrome are behaving well but IE11 need it. */
-  --item-margin: .8em;
-  --item-real-margin: .7em
+  --item-size: 8rem;
+  --item-mobile-size: 5rem;
 }
 
 .sto-small-app-item {
   position: relative;
   display: flex;
-  flex-direction: row;
-  flex-grow: 1;
-  flex-shrink: 1;
-  flex-basis: calc(100% - var(--item-margin) * 2);
-  padding: var(--item-real-margin);
+  flex-direction: column;
+  flex-grow: 0;
+  flex-shrink: 0;
+  flex-basis: var(--item-size);
+  height: var(--item-size);
+  align-items: center;
+  justify-content: start;
+  background: white;
+  box-shadow: none;
+  border-radius: 4px;
+  border: solid 1px var(--silver);
+  padding: calc(.75rem / 2 - 1px);
   margin-bottom: 1rem;
+  margin-right: 1rem;
+  overflow: hidden;
+  transition: .15s ease all;
+}
+
+.sto-small-app-item:last-child {
+  margin-right: 0;
 }
 
 .sto-small-app-item:hover {
-  background: var(--paleGrey);
-  box-shadow: 0 0 0 0 var(--paleGrey);
+  box-shadow: 0 4px 12px 0 #00000020;
   cursor: pointer;
+  transform: scale(1.1);
+  transition: .15s ease all;
+}
+
+.sto-small-app-item-icon-wrapper {
+  margin-top: .25rem;
+  margin-bottom: .25rem;
 }
 
 .sto-small-app-item-icon {
-  height: 100%;
   object-fit: contain;
+  max-width: 3rem;
+  max-height: 3rem;
 }
 
 .sto-small-app-item-icon--default {
   height: 100%;
-  width: 3em;
   padding: 0 .5em;
 }
 
 .sto-small-app-item-desc {
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: start;
+  align-items: center;
   height: 100%;
-  margin-left: 1em;
+  margin-top: .5rem;
+  text-align: center;
 }
 
-.sto-small-app-item-text {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-}
-
-.sto-small-app-item-title, .sto-small-app-item-detail {
-  flex: 0 1;
-  width: 100%;
+.sto-small-app-item-title, .sto-small-app-item-developer, .sto-small-app-item-status {
+  display: block;
+  width: var(--item-size);
   margin: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
-.sto-small-app-item-detail {
-  margin: .2em 0;
-  font-size: .8rem;
+.sto-small-app-item-title {
+  height: 1.5rem;
+}
+
+.sto-small-app-item-developer {
+  height: 1rem;
+  font-size: 12px;
+  color: var(--slateGrey);
+}
+
+.sto-small-app-item-status {
+  margin-top: .5rem;
+  height: 1rem;
+  font-size: 12px;
   color: var(--coolGrey);
 }
 
-.sto-small-app-item-buttons {
-  display: flex;
-}
-
-.sto-small-app-item-desc .sto-small-app-item-button {
-  margin-left: 0;
-}
-
-.sto-small-app-item-button-install,
-.sto-small-app-item-button-install:visited {
-  color: var(--dodgerBlue);
-  background: white;
-  font-weight: 700;
-}
-
-.sto-small-app-item-button-install:hover,
-.sto-small-app-item-button-install:focus,
-.sto-small-app-item-button-install:active {
-  color: white;
-  background: var(--dodgerBlue);
-}
-
-@media (min-width: 25rem) and (max-width: 38rem) {
+@media (max-width: 64rem) {
   .sto-small-app-item {
-    justify-content: space-between;
+    flex-basis: var(--item-mobile-size);
+    height: var(--item-mobile-size);
   }
-  .sto-small-app-item-buttons {
-    margin-left: .5rem;
+
+  .sto-small-app-item-developer {
+    display: none;
   }
+
+  .sto-small-app-item-title, .sto-small-app-item-developer, .sto-small-app-item-status {
+    width: var(--item-mobile-size);
+  }
+
+  .sto-small-app-item-icon-wrapper {
+    margin-bottom: 0;
+  }
+
+  .sto-small-app-item-icon {
+    height: 2.5rem;
+    max-width: 2.5rem;
+    max-height: 2.5rem;
+  }
+
   .sto-small-app-item-desc {
-    flex-direction: row;
-    flex-grow: 1;
-    justify-content: space-between;
+    margin-top: .125rem;
   }
 
-  .sto-small-app-item-desc .sto-small-app-item-button {
-    align-self: center;
+  .sto-small-app-item-title {
+    height: 1rem;
+    font-weight: normal;
+    font-size: 12px;
   }
-}
 
-@media (min-width: 38rem) {
-  .sto-small-app-item {
-    flex-grow: 0;
-  }
-}
-
-@media (min-width: 38rem) {
-  .sto-small-app-item {
-    flex-basis: calc(50% - var(--item-margin) * 2);
-  }
-}
-
-@media (min-width: 70rem) {
-  .sto-small-app-item {
-    flex-basis: calc(33.333% - var(--item-margin) * 2);
-  }
-}
-
-@media (min-width: 90rem) {
-  .sto-small-app-item {
-    flex-basis: calc(25% - var(--item-margin) * 2);
-  }
-}
-
-@media (min-width: 112rem) {
-  .sto-small-app-item {
-    flex-basis: calc(20% - var(--item-margin) * 2);
-  }
-}
-
-@media (min-width: 128rem) {
-  .sto-small-app-item {
-    flex-basis: calc(16.666% - var(--item-margin) * 2);
+  .sto-small-app-item-status {
+    margin-top: .125rem;
   }
 }

--- a/test/components/__snapshots__/smallAppItem.spec.js.snap
+++ b/test/components/__snapshots__/smallAppItem.spec.js.snap
@@ -7,44 +7,30 @@ exports[`SmallAppItem component should be rendered correctly an app 1`] = `
   onKeyDown={[Function]}
   tabIndex={0}
 >
-  <img
-    alt="test-icon"
-    className="sto-small-app-item-icon"
-    height="64"
-    src="<svg></svg>"
-    width="64"
-  />
+  <div
+    className="sto-small-app-item-icon-wrapper"
+  >
+    <img
+      alt="test-icon"
+      className="sto-small-app-item-icon"
+      height="64"
+      src="<svg></svg>"
+      width="64"
+    />
+  </div>
   <div
     className="sto-small-app-item-desc"
   >
-    <div
-      className="sto-small-app-item-text"
+    <h4
+      className="sto-small-app-item-title"
     >
-      <h4
-        className="sto-small-app-item-title"
-      >
-        Cozy Test
-      </h4>
-      <p
-        className="sto-small-app-item-detail"
-      >
-        Cozy
-      </p>
-    </div>
-    <div
-      className="sto-small-app-item-buttons"
+      Cozy Test
+    </h4>
+    <p
+      className="sto-small-app-item-developer"
     >
-      <Link
-        className="c-btn c-btn--regular c-btn--tiny sto-small-app-item-button sto-small-app-item-button-install"
-        onClick={[Function]}
-        replace={false}
-        to="/discover/test/manage"
-      >
-        <span>
-          Install
-        </span>
-      </Link>
-    </div>
+      Cozy
+    </p>
   </div>
 </div>
 `;
@@ -56,41 +42,35 @@ exports[`SmallAppItem component should be rendered correctly an installed app 1`
   onKeyDown={[Function]}
   tabIndex={0}
 >
-  <img
-    alt="test2-icon"
-    className="sto-small-app-item-icon"
-    height="64"
-    src="<svg></svg>"
-    width="64"
-  />
+  <div
+    className="sto-small-app-item-icon-wrapper"
+  >
+    <img
+      alt="test2-icon"
+      className="sto-small-app-item-icon"
+      height="64"
+      src="<svg></svg>"
+      width="64"
+    />
+  </div>
   <div
     className="sto-small-app-item-desc"
   >
-    <div
-      className="sto-small-app-item-text"
+    <h4
+      className="sto-small-app-item-title"
     >
-      <h4
-        className="sto-small-app-item-title"
-      >
-        Test2
-      </h4>
-      <p
-        className="sto-small-app-item-detail"
-      >
-        Naming me
-      </p>
-    </div>
-    <div
-      className="sto-small-app-item-buttons"
+      Test2
+    </h4>
+    <p
+      className="sto-small-app-item-developer"
     >
-      <DefaultButton
-        className="sto-small-app-item-button"
-        label="Open"
-        onClick={[Function]}
-        size="tiny"
-        theme="secondary"
-      />
-    </div>
+      Naming me
+    </p>
+    <p
+      className="sto-small-app-item-status"
+    >
+      Installed
+    </p>
   </div>
 </div>
 `;
@@ -102,42 +82,36 @@ exports[`SmallAppItem component should be rendered correctly an installed app wi
   onKeyDown={[Function]}
   tabIndex={0}
 >
-  <Icon
-    className="sto-small-app-item-icon--default blurry"
-    color="#95999D"
-    height="64"
-    icon="test-file-stub"
-    spin={false}
-    width="48"
-  />
+  <div
+    className="sto-small-app-item-icon-wrapper"
+  >
+    <Icon
+      className="sto-small-app-item-icon sto-small-app-item-icon--default blurry"
+      color="#95999D"
+      height="64"
+      icon="test-file-stub"
+      spin={false}
+      width="48"
+    />
+  </div>
   <div
     className="sto-small-app-item-desc"
   >
-    <div
-      className="sto-small-app-item-text"
+    <h4
+      className="sto-small-app-item-title"
     >
-      <h4
-        className="sto-small-app-item-title"
-      >
-        Cozy Test2
-      </h4>
-      <p
-        className="sto-small-app-item-detail"
-      >
-        Naming me
-      </p>
-    </div>
-    <div
-      className="sto-small-app-item-buttons"
+      Cozy Test2
+    </h4>
+    <p
+      className="sto-small-app-item-developer"
     >
-      <DefaultButton
-        className="sto-small-app-item-button"
-        label="Open"
-        onClick={[Function]}
-        size="tiny"
-        theme="secondary"
-      />
-    </div>
+      Naming me
+    </p>
+    <p
+      className="sto-small-app-item-status"
+    >
+      Installed
+    </p>
   </div>
 </div>
 `;

--- a/test/components/smallAppItem.spec.js
+++ b/test/components/smallAppItem.spec.js
@@ -7,7 +7,6 @@ import Enzyme, { shallow } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 
 import { tMock } from '../jestLib/I18n'
-import { Link } from 'react-router-dom'
 import { SmallAppItem } from '../../src/ducks/components/SmallAppItem'
 
 Enzyme.configure({ adapter: new Adapter() })
@@ -91,32 +90,5 @@ describe('SmallAppItem component', () => {
       .find('div.sto-small-app-item')
       .simulate('keydown', { keyCode: 13 })
     expect(appMock.onClick.mock.calls.length).toBe(1)
-  })
-
-  it('should redirect correctly to the app if installed', () => {
-    window.location.assign = jest.fn()
-    const mockEventStopPropagation = jest.fn()
-    const component = shallow(<SmallAppItem t={tMock} {...appMock2} />)
-    component
-      .find('.sto-small-app-item-button')
-      .simulate('click', { stopPropagation: mockEventStopPropagation })
-    expect(window.location.assign.mock.calls.length).toBe(1)
-    expect(window.location.assign.mock.calls[0][0]).toBe(
-      appMock2.installedAppLink
-    )
-    expect(mockEventStopPropagation.mock.calls.length).toBe(1)
-  })
-
-  it('should open the app installing modal if not installed', () => {
-    const mockEventStopPropagation = jest.fn()
-    const component = shallow(<SmallAppItem t={tMock} {...appMock} />)
-    const linkComponent = component.find(Link)
-    expect(linkComponent.getElement().props.to).toBe(
-      `/discover/${appMock.slug}/manage`
-    )
-    linkComponent.simulate('click', {
-      stopPropagation: mockEventStopPropagation
-    })
-    expect(mockEventStopPropagation.mock.calls.length).toBe(1)
   })
 })

--- a/test/ducks/apps/components/__snapshots__/discover.spec.js.snap
+++ b/test/ducks/apps/components/__snapshots__/discover.spec.js.snap
@@ -1097,7 +1097,7 @@ exports[`Discover component should render correctly a spinner if apps is fetchin
     uninstallApp={undefined}
     updateApp={undefined}
   />
-  <AppsLoading />
+  <Aware />
 </Content>
 `;
 

--- a/test/ducks/apps/components/__snapshots__/myApplications.spec.js.snap
+++ b/test/ducks/apps/components/__snapshots__/myApplications.spec.js.snap
@@ -720,7 +720,7 @@ exports[`MyApplications component should render correctly a spinner if apps is f
     uninstallApp={[MockFunction]}
     updateApp={undefined}
   />
-  <AppsLoading />
+  <Aware />
 </Content>
 `;
 


### PR DESCRIPTION
Web
<img width="959" alt="screen shot 2018-07-10 at 01 16 04" src="https://user-images.githubusercontent.com/10224453/42480668-e21f067e-83de-11e8-9b9a-a637599acbb9.png">

Mobile
<img width="661" alt="screen shot 2018-07-10 at 01 16 14" src="https://user-images.githubusercontent.com/10224453/42480670-e3d8559c-83de-11e8-8906-165055a36dfa.png">

Also fit the loading view with the new grid.