### PR TITLE
Better handling modals routing with history.replace

### DIFF
--- a/src/ducks/apps/components/ApplicationRouting.jsx
+++ b/src/ducks/apps/components/ApplicationRouting.jsx
@@ -29,26 +29,26 @@ export class ApplicationRouting extends Component {
       const { history, location, parent, t } = this.props
       const pathRegex = new RegExp(`^/${parent}/([^/]*)/.*`)
       const matches = location.pathname.match(pathRegex)
-      if (!matches || matches.length < 1) return history.push(`/${parent}/`)
+      if (!matches || matches.length < 1) return history.replace(`/${parent}/`)
       const app = this.getAppFromMatchOrSlug(null, matches[1])
       if (app.type === APP_TYPE.KONNECTOR) {
-        return history.push(`/${parent}/${app.slug}/configure`)
+        return history.replace(`/${parent}/${app.slug}/configure`)
       } else {
         Alerter.success(t('app_modal.install.message.install_success'), {
           duration: 3000
         })
-        return history.push(`/${parent}/${app.slug}`)
+        return history.replace(`/${parent}/${app.slug}`)
       }
     } else if (this.props.isUninstalling && !nextProps.isUninstalling) {
       const { history, location, parent, t } = this.props
       const pathRegex = new RegExp(`^/${parent}/([^/]*)/.*`)
       const matches = location.pathname.match(pathRegex)
-      if (!matches || matches.length < 1) return history.push(`/${parent}/`)
+      if (!matches || matches.length < 1) return history.replace(`/${parent}/`)
       const app = this.getAppFromMatchOrSlug(null, matches[1])
       Alerter.success(t('app_modal.uninstall.message.success'), {
         duration: 3000
       })
-      return history.push(`/${parent}/${app.slug}`)
+      return history.replace(`/${parent}/${app.slug}`)
     }
   }
 
@@ -81,7 +81,7 @@ export class ApplicationRouting extends Component {
           render={({ match }) => {
             if (isFetching) return
             const app = this.getAppFromMatchOrSlug(match)
-            if (!app) return history.push(`/${parent}`)
+            if (!app) return history.replace(`/${parent}`)
             return <ApplicationPage app={app} parent={parent} />
           }}
         />
@@ -90,13 +90,13 @@ export class ApplicationRouting extends Component {
           render={({ match }) => {
             if (isFetching) return
             const app = this.getAppFromMatchOrSlug(match)
-            if (!app || !app.isInRegistry) return history.push(`/${parent}`)
+            if (!app || !app.isInRegistry) return history.replace(`/${parent}`)
             const channel = match.params.channel
             const isChannelAvailable = Object.values(
               REGISTRY_CHANNELS
             ).includes(channel)
             if (!isChannelAvailable) {
-              return history.push(`/${parent}/${app.slug}/manage`)
+              return history.replace(`/${parent}/${app.slug}/manage`)
             }
             return (
               <InstallModal
@@ -118,10 +118,10 @@ export class ApplicationRouting extends Component {
           render={({ match }) => {
             if (isFetching) return
             const app = this.getAppFromMatchOrSlug(match)
-            if (!app) return history.push(`/${parent}`)
+            if (!app) return history.replace(`/${parent}`)
             if (app && app.installed) {
               if (!app.uninstallable)
-                return history.push(`/${parent}/${app.slug}`)
+                return history.replace(`/${parent}/${app.slug}`)
               return (
                 <UninstallModal
                   uninstallApp={uninstallApp}
@@ -148,7 +148,7 @@ export class ApplicationRouting extends Component {
           render={({ match }) => {
             if (isFetching) return
             const app = this.getAppFromMatchOrSlug(match)
-            if (!app) return history.push(`/${parent}`)
+            if (!app) return history.replace(`/${parent}`)
             return <PermissionsModal app={app} parent={`/${parent}`} />
           }}
         />
@@ -157,8 +157,8 @@ export class ApplicationRouting extends Component {
           render={({ match }) => {
             if (isFetching) return
             const app = this.getAppFromMatchOrSlug(match)
-            if (!app) return history.push(`/${parent}`)
-            const goToApp = () => history.push(`/${parent}/${app.slug}`)
+            if (!app) return history.replace(`/${parent}`)
+            const goToApp = () => history.replace(`/${parent}/${app.slug}`)
             if (app && app.installed && app.type === APP_TYPE.KONNECTOR) {
               return (
                 <IntentModal

--- a/test/ducks/apps/components/applicationRouting.spec.js
+++ b/test/ducks/apps/components/applicationRouting.spec.js
@@ -27,7 +27,7 @@ const getMockProps = (
   installedApps,
   isFetching,
   parent,
-  history: { push: jest.fn() },
+  history: { push: jest.fn(), replace: jest.fn() },
   uninstallApp: jest.fn().mockName('mockUninstallApp'),
   installApp: jest.fn().mockName('mockInstallApp'),
   updateApp: jest.fn().mockName('mockUpdateApp')
@@ -72,8 +72,8 @@ describe('ApplicationRouting component with ApplicationPage', () => {
     // collect in mockApps is installed and isInRegistry
     const routeProps = { match: { params: { appSlug: 'mock' } } }
     const resultComponent = routeToAppPage.props.render(routeProps)
-    expect(mockProps.history.push.mock.calls.length).toBe(1)
-    expect(mockProps.history.push.mock.calls[0][0]).toBe(`/${parent}`)
+    expect(mockProps.history.replace.mock.calls.length).toBe(1)
+    expect(mockProps.history.replace.mock.calls[0][0]).toBe(`/${parent}`)
     expect(resultComponent).toBeUndefined()
   })
 
@@ -151,8 +151,8 @@ describe('ApplicationRouting component with Modal', () => {
     // collect in mockApps is installed and isInRegistry
     const routeProps = { match: { params: { appSlug: 'mock' } } }
     const resultComponent = routeToModal.props.render(routeProps)
-    expect(mockProps.history.push.mock.calls.length).toBe(1)
-    expect(mockProps.history.push.mock.calls[0][0]).toBe(`/${parent}`)
+    expect(mockProps.history.replace.mock.calls.length).toBe(1)
+    expect(mockProps.history.replace.mock.calls[0][0]).toBe(`/${parent}`)
     expect(resultComponent).toBeUndefined()
   })
 
@@ -236,8 +236,8 @@ describe('ApplicationRouting component with Channel install', () => {
       match: { params: { appSlug: 'mock', channel: 'beta' } }
     }
     const resultComponent = routeToModal.props.render(routeProps)
-    expect(mockProps.history.push.mock.calls.length).toBe(1)
-    expect(mockProps.history.push.mock.calls[0][0]).toBe(`/${parent}`)
+    expect(mockProps.history.replace.mock.calls.length).toBe(1)
+    expect(mockProps.history.replace.mock.calls[0][0]).toBe(`/${parent}`)
     expect(resultComponent).toBeUndefined()
   })
 
@@ -253,8 +253,8 @@ describe('ApplicationRouting component with Channel install', () => {
       match: { params: { appSlug: 'drive', channel: 'beta' } }
     }
     const resultComponent = routeToModal.props.render(routeProps)
-    expect(mockProps.history.push.mock.calls.length).toBe(1)
-    expect(mockProps.history.push.mock.calls[0][0]).toBe(`/${parent}`)
+    expect(mockProps.history.replace.mock.calls.length).toBe(1)
+    expect(mockProps.history.replace.mock.calls[0][0]).toBe(`/${parent}`)
     expect(resultComponent).toBeUndefined()
   })
 
@@ -270,8 +270,8 @@ describe('ApplicationRouting component with Channel install', () => {
       match: { params: { appSlug: 'collect', channel: 'mock' } }
     }
     const resultComponent = routeToModal.props.render(routeProps)
-    expect(mockProps.history.push.mock.calls.length).toBe(1)
-    expect(mockProps.history.push.mock.calls[0][0]).toBe(
+    expect(mockProps.history.replace.mock.calls.length).toBe(1)
+    expect(mockProps.history.replace.mock.calls[0][0]).toBe(
       `/${parent}/collect/manage`
     )
     expect(resultComponent).toBeUndefined()
@@ -342,8 +342,8 @@ describe('ApplicationRouting component with IntentModal', () => {
     // konnector-trinlane in mockApps is installed and isInRegistry
     const routeProps = { match: { params: { appSlug: 'mock' } } }
     const resultComponent = routeToModal.props.render(routeProps)
-    expect(mockProps.history.push.mock.calls.length).toBe(1)
-    expect(mockProps.history.push.mock.calls[0][0]).toBe(`/${parent}`)
+    expect(mockProps.history.replace.mock.calls.length).toBe(1)
+    expect(mockProps.history.replace.mock.calls[0][0]).toBe(`/${parent}`)
     expect(resultComponent).toBeUndefined()
   })
 


### PR DESCRIPTION
We now use `history.replace` in the ApplicationRouting component instead of `history.push` to handle modals state. It will replace the current history browser state instead of push a new one. We use that to avoid getting back to the uninstall modal (for example) by using the browser "previous button".