### PR TITLE
feat: Add translation for cc.cozycloud.autocategorization

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -187,6 +187,7 @@
     },
     "cc": {
       "cozycloud": {
+        "autocategorization": "Categorization model enrichment file",
         "sentry": "The application logs"
       }
     },


### PR DESCRIPTION
Add translation for the new cc.cozycloud.autocategorization remote doctype used by banks

#### Checklist

Before merging this PR, the following things must have been done:

- [x] Localized in english and french
- [x] Make sure commit messages rely on the [Commitizen](http://commitizen.github.io/cz-cli/) format
