### PR TITLE
Minor modal UI fixes

### DIFF
--- a/src/ducks/apps/components/PermissionsModal.jsx
+++ b/src/ducks/apps/components/PermissionsModal.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 
 import Modal, { ModalContent } from 'cozy-ui/react/Modal'
 import { translate } from 'cozy-ui/react/I18n'
+import { SubTitle } from 'cozy-ui/react/Text'
 
 import { withRouter } from 'react-router-dom'
 import TransparencyLabel from './TransparencyLabel'
@@ -18,7 +19,7 @@ export class PermissionsModal extends Component {
   }
 
   render(props) {
-    const { app } = props
+    const { t, app } = props
     // this part must not be wrapped in a component
     // so we get the content using it as a function
     const animatedHeader = AnimatedModalHeader({
@@ -28,6 +29,9 @@ export class PermissionsModal extends Component {
       <Modal secondaryAction={() => this.gotoParent()} mobileFullscreen>
         <ModalContent>
           {animatedHeader}
+          <SubTitle className="sto-modal-title">
+            {t('permissions.title')}
+          </SubTitle>
           <TransparencyLabel app={app} />
         </ModalContent>
       </Modal>

--- a/src/ducks/apps/components/UninstallModal.jsx
+++ b/src/ducks/apps/components/UninstallModal.jsx
@@ -7,7 +7,6 @@ import { translate } from 'cozy-ui/react/I18n'
 import Modal, { ModalContent } from 'cozy-ui/react/Modal'
 
 import ReactMarkdownWrapper from 'ducks/components/ReactMarkdownWrapper'
-import AnimatedModalHeader from 'ducks/components/AnimatedModalHeader'
 
 export class UninstallModal extends Component {
   constructor(props) {
@@ -39,14 +38,14 @@ export class UninstallModal extends Component {
       this.gotoParent()
       return null
     }
-    const animatedHeader = AnimatedModalHeader({
-      app
-    })
     return (
       <div className="sto-modal--uninstall">
-        <Modal dismissAction={this.gotoParent} mobileFullscreen>
+        <Modal
+          dismissAction={this.gotoParent}
+          mobileFullscreen
+          title={t('app_modal.uninstall.title')}
+        >
           <ModalContent>
-            {animatedHeader}
             <div className="sto-modal-content">
               <ReactMarkdownWrapper
                 source={t('app_modal.uninstall.description', {

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -512,7 +512,7 @@ export async function getFormattedRegistryApp(
     Number.isInteger(responseApp.label) &&
     responseApp.label <= 5 &&
     responseApp.label >= 0
-      ? LABELS[label]
+      ? LABELS[responseApp.label]
       : null
   return Object.assign(
     {},

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -80,7 +80,7 @@
     },
     "A": {
       "description": "__Index A:__ You are technically the only one who can consult the data of this service, even the administrators of your Cozy have no way to access it.",
-      "details": "The encryption technology makes you the only one allowed of accessing or transferring data to third parties. You have the key (=your password) to decrypt this content.  \nSo what happens if you lose that key? Cozy Cloud offers you a recovery service thanks to the third parties that you trust. __[Learn more.]()__"
+      "details": "The encryption technology makes you the only one allowed of accessing or transferring data to third parties. You have the key (your password) to decrypt this content.  \nSo what happens if you lose that key? Cozy Cloud offers you a recovery service thanks to the third parties that you trust."
     },
     "B": {
       "description": "__Index B:__ This service is developed by your hosting provider Cozy Cloud, which undertakes that no data will be shared / transmitted to a third party.",
@@ -88,7 +88,7 @@
     },
     "C": {
       "description": "__Index C:__ No data will come out of your Cozy, the developer of this service is committed and can be auditable anytime.",
-      "details": "You enter the login and password of your %{appName} account  in order that your Cozy can retrieve the personal data stored by %{appName}.  \nThis password and data will pass directly from the %{appName} service to your Cozy and will not be made accessible from anyone but yourself. The developer's commitment is auditable because the code is open source. __[Learn more.]()__"
+      "details": "You enter the login and password of your %{appName} account  in order that your Cozy can retrieve the personal data stored by %{appName}.  \nThis password and data will pass directly from the %{appName} service to your Cozy and will not be made accessible from anyone but yourself. The developer's commitment is auditable because the code is open source."
     },
     "D": {
       "description": "__Index D:__ Some data are shared but only to provide you this service.",
@@ -100,7 +100,7 @@
     },
     "F": {
       "description": "__Index F:__ The developer of this application asks you under your consent to provide some data from your Cozy in exchange for its service.",
-      "details": "Please consult and validate the Terms of Service %{vendorLink} developed by %{appName} __[here]()__"
+      "details": "Please consult and validate the Terms of Service %{vendorLink} developed by %{appName} __[here](%{vendorLink})__"
     }
   },
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -62,6 +62,7 @@
   },
 
   "permissions": {
+    "title": "Data access requirements",
     "linxo": "Display your banking accounts in your Cozy, thanks to the secured connexion to your bank by our partner Linxo ([linxo.com](https://linxo.com))",
     "reason": "**Reason: **",
     "developer_default": "The developer of this application",

--- a/test/ducks/apps/components/__snapshots__/uninstallModal.spec.js.snap
+++ b/test/ducks/apps/components/__snapshots__/uninstallModal.spec.js.snap
@@ -12,31 +12,9 @@ exports[`UninstallModal component should be rendered correctly (app uninstallabl
     primaryType="regular"
     secondaryType="secondary"
     size="small"
+    title="Uninstall this application"
   >
     <ModalContent>
-      <AnimatedContentHeader
-        activeClassName="sto-animated-header--active"
-        className="sto-animated-header"
-      >
-        <img
-          alt="photos-icon"
-          className="sto-animated-header-icon"
-          src="<svg></svg>"
-        />
-        <Icon
-          className="sto-animated-header-exchange"
-          color="#95999D"
-          icon="exchange"
-          spin={false}
-        />
-        <Icon
-          className="sto-animated-header-icon"
-          height="56"
-          icon="test-file-stub"
-          spin={false}
-          width="56"
-        />
-      </AnimatedContentHeader>
       <div
         className="sto-modal-content"
       >
@@ -83,31 +61,9 @@ exports[`UninstallModal component should handle correctly error from props 1`] =
     primaryType="regular"
     secondaryType="secondary"
     size="small"
+    title="Uninstall this application"
   >
     <ModalContent>
-      <AnimatedContentHeader
-        activeClassName="sto-animated-header--active"
-        className="sto-animated-header"
-      >
-        <img
-          alt="photos-icon"
-          className="sto-animated-header-icon"
-          src="<svg></svg>"
-        />
-        <Icon
-          className="sto-animated-header-exchange"
-          color="#95999D"
-          icon="exchange"
-          spin={false}
-        />
-        <Icon
-          className="sto-animated-header-icon"
-          height="56"
-          icon="test-file-stub"
-          spin={false}
-          width="56"
-        />
-      </AnimatedContentHeader>
       <div
         className="sto-modal-content"
       >


### PR DESCRIPTION
* Remove animated header from uninstall modal
* Get back modal title in the permissions modal
* Typo on label reading
* Remove empty links in locales 