### PR TITLE
Due to cozy-realtime upgrade, the library does not use cozyclient as first parameter

### DIFF
--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -413,9 +413,15 @@ function onAppDelete(appResponse) {
 }
 
 function initializeRealtime() {
+  const config = {
+    token: cozy.client._token.token,
+    // cozy-realtime expect an URL with an https protocol,
+    // see https://github.com/cozy/cozy-libs/blob/master/packages/realtime/src/index.js#L52
+    url: `${window.location.protocol}${cozy.client._url}`
+  }
   return async dispatch => {
     realtime
-      .subscribeAll(cozy.client, APPS_DOCTYPE)
+      .subscribeAll(config, APPS_DOCTYPE)
       .then(subscription => {
         // HACK: the push CREATE at fisrt install
         subscription.onCreate(app => dispatch(onAppUpdate(app)))


### PR DESCRIPTION
Realtime in store is broken, as cozy-realtime is now intiialized with a config object and not cozy-client anymore.

So in this PR we got the domain and token from the top component, index.jsx.

This is not the best solution imho as the property is passed from component to subcomponents. We should better in the future use a global Cozy object for configuration, or maybe create a `<Cozy />` component which should pass all we need in the context.