### PR TITLE
Use intent redirection to open konnector

### DIFF
--- a/src/ducks/apps/components/ApplicationPage/Header.jsx
+++ b/src/ducks/apps/components/ApplicationPage/Header.jsx
@@ -1,3 +1,4 @@
+/* global cozy */
 import React from 'react'
 import { Link } from 'react-router-dom'
 
@@ -8,6 +9,7 @@ import { translate } from 'cozy-ui/react/I18n'
 import cozySmileIcon from 'assets/icons/icon-cozy-smile.svg'
 import defaultAppIcon from 'assets/icons/icon-cube.svg'
 import { Placeholder } from 'ducks/components/AppsLoading'
+import AsyncButton from 'ducks/components/AsyncButton'
 
 import { APP_TYPE } from 'ducks/apps'
 import {
@@ -53,16 +55,25 @@ export const Header = ({ t, app, namePrefix, name, description, parent }) => {
         </h2>
         <p className="sto-app-header-description">{description}</p>
         {isInstalledAndNothingToReport(app) ? (
-          <Button
-            onClick={() => openApp(related)}
-            className="c-btn"
-            icon="openwith"
-            label={
-              isKonnector
-                ? t('app_page.konnector.open')
-                : t('app_page.webapp.open')
-            }
-          />
+          isKonnector ? (
+            <AsyncButton
+              asyncAction={() =>
+                cozy.client.intents.redirect('io.cozy.accounts', {
+                  konnector: app.slug
+                })
+              }
+              className="c-btn"
+              icon="openwith"
+              label={t('app_page.konnector.open')}
+            />
+          ) : (
+            <Button
+              onClick={() => openApp(related)}
+              className="c-btn"
+              icon="openwith"
+              label={t('app_page.webapp.open')}
+            />
+          )
         ) : (
           <Link
             to={`/${parent}/${slug}/install`}

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -31,8 +31,6 @@ const KONNECTORS_DOCTYPE = 'io.cozy.konnectors'
 
 const AUTHORIZED_CATEGORIES = categories
 
-const COLLECT_RELATED_PATH = constants.collect
-
 const DEFAULT_CHANNEL = constants.default.registry.channel
 
 // initial loading
@@ -312,19 +310,12 @@ export function fetchIconsProgressively() {
   }
 }
 
-export async function getFormattedInstalledApp(
-  response,
-  collectLink,
-  fetchIcon = true
-) {
+export async function getFormattedInstalledApp(response, fetchIcon = true) {
   const appAttributes = _sanitizeManifest(response.attributes)
 
   let icon = response.links.icon
   if (fetchIcon) icon = await _getIcon(icon)
-  const openingLink =
-    appAttributes.type === APP_TYPE.KONNECTOR
-      ? `${collectLink}/${COLLECT_RELATED_PATH}/${appAttributes.slug}`
-      : response.links.related
+  const openingLink = response.links.related
   const screensLinks =
     appAttributes.screenshots &&
     appAttributes.screenshots.map(name => {
@@ -381,10 +372,7 @@ function onAppUpdate(appResponse) {
         'GET',
         `/${route}/${appResponse.slug}`
       )
-      // TODO throw error if collect is not installed
-      const collectApp = getState().apps.list.find(a => a.slug === 'collect')
-      const collectLink = collectApp && collectApp.related
-      return getFormattedInstalledApp(appFromStack, collectLink).then(app => {
+      return getFormattedInstalledApp(appFromStack).then(app => {
         // add the installed app to the state apps list
         const apps = getState().apps.list.map(a => {
           if (a.slug === app.slug) {

--- a/src/ducks/components/AsyncButton.jsx
+++ b/src/ducks/components/AsyncButton.jsx
@@ -1,0 +1,44 @@
+import React, { Component } from 'react'
+
+import Button from 'cozy-ui/react/Button'
+
+const IDLE = 'idle'
+const WORKING = 'working'
+
+class AsyncButton extends Component {
+  constructor(props, context) {
+    super(props, context)
+    this.state = {
+      isFunctional: typeof props.asyncAction === 'function',
+      status: IDLE
+    }
+  }
+
+  asyncAction = () => {
+    const { asyncAction } = this.props
+    const { isFunctional } = this.state
+    if (isFunctional) {
+      this.setState({ status: WORKING })
+      try {
+        asyncAction()
+      } catch (error) {
+        this.setState({ status: IDLE })
+      }
+    }
+  }
+
+  render() {
+    const { isFunctional, status } = this.state
+    const isWorking = status === WORKING
+    return (
+      <Button
+        {...this.props}
+        busy={isWorking}
+        disabled={isWorking || !isFunctional}
+        onClick={this.asyncAction}
+      />
+    )
+  }
+}
+
+export default AsyncButton

--- a/test/ducks/apps/components/applicationPage/header.spec.js
+++ b/test/ducks/apps/components/applicationPage/header.spec.js
@@ -83,25 +83,6 @@ describe('ApplicationPage header component', () => {
     expect(window.location.assign.mock.calls[0][0]).toBe('#')
   })
 
-  it('should handle the click on open installed konnector button', () => {
-    const appProps = Object.assign({}, mockKonnector.manifest)
-    appProps.installed = true
-    appProps.icon = '<svg></svg>'
-    appProps.related = '#'
-    const wrapper = shallow(
-      <Header
-        t={tMock}
-        parent="/myapps"
-        app={appProps}
-        name={appProps.name}
-        description={appProps.description}
-      />
-    )
-    wrapper.find(Button).simulate('click')
-    expect(window.location.assign.mock.calls.length).toBe(1)
-    expect(window.location.assign.mock.calls[0][0]).toBe('#')
-  })
-
   it('should disable the install button if maintenance', () => {
     const appProps = Object.assign({}, mockApp.manifest)
     appProps.maintenance = {}


### PR DESCRIPTION
Hotfix to use `home` slug instead of `collect`