### PR TITLE
Save list scroll position

### DIFF
--- a/src/ducks/components/ScrollToTop.jsx
+++ b/src/ducks/components/ScrollToTop.jsx
@@ -3,18 +3,51 @@ import { findDOMNode } from 'react-dom'
 import { withRouter } from 'react-router'
 import withBreakpoints from 'cozy-ui/react/helpers/withBreakpoints'
 
-// a component to automatically reset the scroll
-// on mount (see https://reacttraining.com/react-router/web/guides/scroll-restoration/scroll-to-top)
 export class ScrollToTop extends Component {
-  componentDidUpdate(prevProps) {
+  constructor(props) {
+    super(props)
+    this.state = { scrollListPosition: 0 }
+  }
+
+  getSnapshotBeforeUpdate(prevProps) {
     if (this.props.location !== prevProps.location) {
-      if (!this.props.breakpoints.isDesktop) {
-        document.documentElement.scrollTop = 0
-        document.body.scrollTop = 0 // safari
-      } else {
+      // three length match array
+      const prev = prevProps.location.pathname.match(/^\/([^/?&]*)\/?(.*)/)
+      const next = this.props.location.pathname.match(/^\/([^/?&]*)\/?(.*)/)
+      // if same parent path
+      if (prev && next && prev[1] === next[1]) {
+        if (!prev[2] && next[2]) {
+          // i.e. /discover to /discover/drive
+          // we save the scroll position
+          let scrollState = 0
+          if (this.props.breakpoints.isDesktop) {
+            // eslint-disable-next-line react/no-find-dom-node
+            const domNode = this.props.target && findDOMNode(this.props.target)
+            scrollState = domNode.scrollTop
+          } else {
+            scrollState =
+              document.documentElement.scrollTop || document.body.scrollTop
+          }
+          this.setState({ scrollListPosition: scrollState })
+          return null
+        } else if (prev[2] && !next[2]) {
+          // i.e. /discover/drive to /discover
+          return this.state.scrollListPosition
+        }
+      }
+    }
+    return null
+  }
+
+  componentDidUpdate(prevProps, prevState, scrollSnapshot) {
+    if (this.props.location !== prevProps.location) {
+      if (this.props.breakpoints.isDesktop) {
         // eslint-disable-next-line react/no-find-dom-node
         const domNode = this.props.target && findDOMNode(this.props.target)
-        domNode.scrollTop = 0
+        domNode.scrollTop = scrollSnapshot || 0
+      } else {
+        document.documentElement.scrollTop = scrollSnapshot || 0
+        document.body.scrollTop = scrollSnapshot || 0 // safari
       }
     }
   }


### PR DESCRIPTION
A proposal to save the list scroll position when navigating through the store pages:
* If `/<PARENT>/` to `/<PARENT>/<APP>` -> save the scroll position in state
* If `/<PARENT>/<APP>` to `/<PARENT>` -> use the saved scroll position from state
* Other cases, reset scroll position to 0