### PR TITLE
Intent composition

### DIFF
--- a/src/ducks/components/intents/InstallAppIntent.jsx
+++ b/src/ducks/components/intents/InstallAppIntent.jsx
@@ -34,13 +34,25 @@ export class InstallAppIntent extends Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  async componentWillReceiveProps(nextProps) {
     // on install success
     if (this.props.isInstalling && !nextProps.isInstalling) {
-      this.props.onTerminate(nextProps.app)
       this.setState({
         status: 'installed'
       })
+
+      const { app, compose, data, onTerminate } = this.props
+      const configure = typeof data.configure === 'undefined' || data.configure
+
+      if (app.type === 'konnector' && configure) {
+        await compose(
+          'CREATE',
+          'io.cozy.accounts',
+          { slug: app.slug }
+        )
+      }
+
+      onTerminate(nextProps.app)
     }
   }
 

--- a/src/ducks/components/intents/IntentHandler.jsx
+++ b/src/ducks/components/intents/IntentHandler.jsx
@@ -61,6 +61,7 @@ class IntentHandler extends Component {
           // In the future, we may switch here between available intents
           React.cloneElement(child, {
             appData: appData,
+            compose: service.compose,
             data: service.getData(),
             intent: service.getIntent(),
             onCancel: () => service.cancel(),


### PR DESCRIPTION
WIP: should me merge in ~the future `patch-1.2.5`, once~ `patch-1.2.4` ~will be stable~.

CREATE io.cozy.accounts after INSTALL io.cozy.apps

This PR add an interapp composition right after an interapp installation.
This composition is not performed if the first intent is called with a `configure: false` option.