### PR TITLE
fix: 🐛 Tablet layout

### DIFF
--- a/src/styles/application.css
+++ b/src/styles/application.css
@@ -65,7 +65,7 @@ main > [role=main].sto-myapps {
   overflow: hidden;
 }
 
-@media (max-width: 48rem) {
+@media (max-width: 64rem) {
   main > [role=main].sto-discover,
   main > [role=main].sto-myapps {
     height: 100%;
@@ -85,7 +85,7 @@ main > [role=main].sto-myapps {
 }
 
 
-@media (max-width: 48rem) {
+@media (max-width: 64rem) {
   .has-modal .sto-modal-page {
     position: absolute;
     z-index: auto;


### PR DESCRIPTION
- Content page is scrollable again on Tablet
- Content page is well placed on Tablet.

Basically I extended the behaviour for mobile to tablet as well. That was it.