### PR TITLE
Handle step on app page in intents

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -30,7 +30,8 @@
         "slug",
         "tag",
         "type",
-        "pendingUpdate"
+        "pendingUpdate",
+        "step"
       ]
     },
     {

--- a/src/ducks/components/intents/IntentRedirect.jsx
+++ b/src/ducks/components/intents/IntentRedirect.jsx
@@ -14,7 +14,20 @@ export const IntentRedirect = ({ location }) => {
         return accumulator
       }, {})
 
-  if (query.slug) return <Redirect to={`/discover/${query.slug}`} />
+  if (query.slug) {
+    switch (query.step) {
+      case 'install':
+        return <Redirect to={`/discover/${query.slug}/install`} />
+      case 'update':
+        return <Redirect to={`/discover/${query.slug}/install`} />
+      case 'uninstall':
+        return <Redirect to={`/discover/${query.slug}/uninstall`} />
+      case 'permissions':
+        return <Redirect to={`/discover/${query.slug}/permissions`} />
+      default:
+        return <Redirect to={`/discover/${query.slug}`} />
+    }
+  }
   return <Redirect to={`/discover/${queryString}`} />
 }
 


### PR DESCRIPTION
The need here is to be able to open directly the `install` modal when we use the redirection.
~~I not very happy about the `action` variable naming here but I don't see a very good match here :/~~
We will use the `step` variable to specify `install`, `update`, `permissions` or `uninstall`