### PR TITLE
Improve error message when uninstalling a linked app

### DIFF
--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -507,6 +507,15 @@ export function fetchApps(lang) {
   }
 }
 
+function extractJsonApiError(e) {
+  try {
+    const parsed = JSON.parse(e.message)
+    return new Error(parsed.errors[0].detail || e.message)
+  } catch (err) {
+    return e
+  }
+}
+
 export function uninstallApp(app) {
   const { slug, type } = app
   return dispatch => {
@@ -522,7 +531,7 @@ export function uninstallApp(app) {
     const route =
       type === APP_TYPE.KONNECTOR || type === 'node' ? 'konnectors' : 'apps'
     return cozy.client.fetchJSON('DELETE', `/${route}/${slug}`).catch(e => {
-      dispatch({ type: UNINSTALL_APP_FAILURE, error: e })
+      dispatch({ type: UNINSTALL_APP_FAILURE, error: extractJsonApiError(e) })
     })
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -46,6 +46,10 @@
       "message": {
         "success": "The application has correctly been uninstalled.",
         "error": "Something went wrong when uninstalling this application. Reason: %{message}"
+      },
+      "linked_app": {
+        "error": "A mobile application is linked to this application, it must be revoked to uninstall this application. To do this, you can go on",
+        "link": "your page for managing connected devices"
       }
     },
     "install": {

--- a/test/ducks/apps/components/__snapshots__/uninstallModal.spec.js.snap
+++ b/test/ducks/apps/components/__snapshots__/uninstallModal.spec.js.snap
@@ -30,6 +30,7 @@ exports[`UninstallModal component should be rendered correctly (app uninstallabl
       />
       <DefaultButton
         className="u-mh-half"
+        disabled={false}
         extension="full"
         icon="delete"
         label="Uninstall"
@@ -76,6 +77,62 @@ exports[`UninstallModal component should handle correctly error from props 1`] =
       />
       <DefaultButton
         className="u-mh-half"
+        disabled={false}
+        extension="full"
+        icon="delete"
+        label="Uninstall"
+        onClick={[Function]}
+        theme="danger"
+      />
+    </ModalFooter>
+  </Unknown>
+</Portal>
+`;
+
+exports[`UninstallModal component should handle correctly linked app error 1`] = `
+<Portal
+  into="body"
+>
+  <Unknown
+    className="sto-modal--uninstall"
+    closable={true}
+    mobileFullscreen={true}
+    overflowHidden={false}
+    primaryType="regular"
+    secondaryType="secondary"
+    size="small"
+    title="Uninstall this application"
+  >
+    <ModalContent>
+      <ReactMarkdownWrapper
+        source="This application is bound to be removed from your Cozy cozytest.mock.cc. Are you sure to __remove this application definitively__?"
+      />
+      <p
+        className="u-error"
+      >
+        A mobile application is linked to this application, it must be revoked to uninstall this application. To do this, you can go on
+         
+        <a
+          className="u-c-pointer u-dodgerBlue"
+          onClick={[Function]}
+        >
+          your page for managing connected devices
+        </a>
+        .
+      </p>
+    </ModalContent>
+    <ModalFooter
+      className="sto-modal-controls"
+    >
+      <DefaultButton
+        className="u-mh-half"
+        extension="full"
+        label="Cancel"
+        theme="secondary"
+      />
+      <DefaultButton
+        className="u-mh-half"
+        disabled={true}
         extension="full"
         icon="delete"
         label="Uninstall"

--- a/test/ducks/apps/components/uninstallModal.spec.js
+++ b/test/ducks/apps/components/uninstallModal.spec.js
@@ -70,4 +70,13 @@ describe('UninstallModal component', () => {
     const component = shallow(<UninstallModal t={tMock} {...mockProps} />)
     expect(component.getElement()).toMatchSnapshot()
   })
+
+  it('should handle correctly linked app error', () => {
+    const mockProps = getMockProps(
+      'photos',
+      new Error('A linked OAuth client exists for this app')
+    )
+    const component = shallow(<UninstallModal t={tMock} {...mockProps} />)
+    expect(component.getElement()).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
When the user try to uninstall a web application that is linked to a mobile application, an error message is displayed. Before this PR, the error message was a JSON-API body that is not really clear for most users. Now, it is a localized message, with a link to the connected devices page.

#### Checklist

- [ ] I've updated the english locale file, but I've not yet pushed it to transifex (and translating to french needs to be done after that).