### PR TITLE
Optimize boot

### DIFF
--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -415,12 +415,15 @@ export async function getFormattedRegistryApp(
   )
 }
 
-export function fetchInstalledApps(lang) {
+export function fetchInstalledApps(lang, fetchingRegistry) {
   return async dispatch => {
     dispatch({ type: FETCH_APPS })
     try {
+      // Start the HTTP requests as soon as possible
       let fetchingKonnectors = cozy.client.fetchJSON('GET', '/konnectors/')
-      let installedWebApps = await cozy.client.fetchJSON('GET', '/apps/')
+      let fetchingWebApps = cozy.client.fetchJSON('GET', '/apps/')
+      await fetchingRegistry
+      let installedWebApps = await fetchingWebApps
       installedWebApps = installedWebApps.map(w => {
         // FIXME type konnector is missing from stack
         w.attributes.type = APP_TYPE.WEBAPP
@@ -500,8 +503,8 @@ export function fetchRegistryApps(lang, channel = DEFAULT_CHANNEL) {
 
 export function fetchApps(lang) {
   return async dispatch => {
-    await dispatch(fetchRegistryApps(lang))
-    return dispatch(fetchInstalledApps(lang))
+    const fetchingRegistry = dispatch(fetchRegistryApps(lang))
+    return dispatch(fetchInstalledApps(lang, fetchingRegistry))
   }
 }
 

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -419,6 +419,7 @@ export function fetchInstalledApps(lang) {
   return async dispatch => {
     dispatch({ type: FETCH_APPS })
     try {
+      let fetchingKonnectors = cozy.client.fetchJSON('GET', '/konnectors/')
       let installedWebApps = await cozy.client.fetchJSON('GET', '/apps/')
       installedWebApps = installedWebApps.map(w => {
         // FIXME type konnector is missing from stack
@@ -433,10 +434,7 @@ export function fetchInstalledApps(lang) {
       installedWebApps = installedWebApps.filter(
         app => !config.notDisplayedApps.includes(app.attributes.slug)
       )
-      let installedKonnectors = await cozy.client.fetchJSON(
-        'GET',
-        '/konnectors/'
-      )
+      let installedKonnectors = await fetchingKonnectors
       installedKonnectors = installedKonnectors.map(k => {
         // FIXME type konnector is missing from stack
         k.attributes.type = APP_TYPE.KONNECTOR


### PR DESCRIPTION
The store is currently slow to load the applications. It makes three requests:
- one for fetching apps from the registry
- one for fetching the installed web apps
- one for fetching the installed konnectors.

These 3 requests were sequential. I've tried to make the minimal changes to make them parallel. Maybe you will want to change more things to make the code clearer.