### PR TITLE
Travis: Fix branches directive 🚑

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ node_js:
 branches:
   only:
   - master
+  # tags
+  - /^\d+\.\d+\.\d+(\-beta.\d+)?$/
 env:
   global:
   - TARGETS_DEV=recette.cozy.works


### PR DESCRIPTION
Tag build was broken after https://github.com/cozy/cozy-store/commit/338551c15270ae30b2b10759f7de1f59533e60dc


Using the `only` directive prevent tags from being built.
See https://docs.travis-ci.com/user/customizing-the-build#safelisting-or-blocklisting-branches
(regexp test https://regex101.com/r/wsBW0t/1/)