### PR TITLE
Add permissions skipping feature behing flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "cozy-bar": "6.1.2",
     "cozy-client-js": "0.15.0",
+    "cozy-flags": "1.5.9",
     "cozy-realtime": "2.0.7",
     "cozy-ui": "18.20.0",
     "emoji-js": "3.4.1",

--- a/src/config/constants.json
+++ b/src/config/constants.json
@@ -2,7 +2,8 @@
   "default": {
     "registry": {
       "channel": "stable"
-    }
+    },
+    "authorizedLabelLimit": 3
   },
   "collect": "#/connected"
 }

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -389,11 +389,10 @@ export async function getFormattedRegistryApp(
     })
   return Object.assign(
     {},
-    {
-      versions: responseApp.versions
-    },
     manifest,
     {
+      versions: responseApp.versions,
+      label: responseApp.label,
       version: versionFromRegistry,
       type: version.type,
       categories: _sanitizeCategories(manifest.categories),

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -387,28 +387,24 @@ export async function getFormattedRegistryApp(
     Object.assign({}, manifest.partnership, {
       ...(partnershipIconLink ? { icon: partnershipIconLink } : {})
     })
-  return Object.assign(
-    {},
-    manifest,
-    {
-      versions: responseApp.versions,
-      label: responseApp.label,
-      version: versionFromRegistry,
-      type: version.type,
-      categories: _sanitizeCategories(manifest.categories),
-      links: { icon: iconLink },
-      uninstallable: !config.notRemovableApps.includes(manifest.slug),
-      isInRegistry: true,
-      // Add partnership property only if it exists
-      ...(partnership ? { partnership } : {}),
-      // handle maintenance status
-      ...(maintenance ? { maintenance } : {}),
-      // add screenshotsLinks property only if it exists
-      ...(screenshotsLinks ? { screenshots: screenshotsLinks } : {}),
-      // add installed value only if not already provided
-      installed: responseApp.installed || false
-    }
-  )
+  return Object.assign({}, manifest, {
+    versions: responseApp.versions,
+    label: responseApp.label,
+    version: versionFromRegistry,
+    type: version.type,
+    categories: _sanitizeCategories(manifest.categories),
+    links: { icon: iconLink },
+    uninstallable: !config.notRemovableApps.includes(manifest.slug),
+    isInRegistry: true,
+    // Add partnership property only if it exists
+    ...(partnership ? { partnership } : {}),
+    // handle maintenance status
+    ...(maintenance ? { maintenance } : {}),
+    // add screenshotsLinks property only if it exists
+    ...(screenshotsLinks ? { screenshots: screenshotsLinks } : {}),
+    // add installed value only if not already provided
+    installed: responseApp.installed || false
+  })
 }
 
 export function fetchInstalledApps(lang, fetchingRegistry) {

--- a/src/ducks/components/App.jsx
+++ b/src/ducks/components/App.jsx
@@ -4,6 +4,7 @@ import { hot } from 'react-hot-loader'
 
 import { Route, Switch, Redirect, withRouter } from 'react-router-dom'
 import { translate } from 'cozy-ui/react/I18n'
+import flag, { FlagSwitcher } from 'cozy-flags'
 
 import IntentRedirect from './intents/IntentRedirect'
 import Sidebar from './Sidebar'
@@ -24,6 +25,7 @@ export class App extends Component {
   render() {
     return (
       <Layout>
+        {flag('switcher') && <FlagSwitcher />}
         <Alerter />
         <Sidebar />
         <Main>

--- a/src/ducks/components/App.jsx
+++ b/src/ducks/components/App.jsx
@@ -43,12 +43,12 @@ export class App extends Component {
   }
 }
 
-const mapStateToProps = state => ({
+export const mapStateToProps = state => ({
   isFetching: state.apps.isFetching,
   isInstalling: state.apps.isInstalling
 })
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
+export const mapDispatchToProps = (dispatch, ownProps) => ({
   initApp: () => dispatch(initApp(ownProps.lang)),
   restoreAppIfSaved: () => dispatch(restoreAppIfSaved())
 })

--- a/src/styles/install.css
+++ b/src/styles/install.css
@@ -1,8 +1,24 @@
+.sto-install-loading-wrapper {
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+  min-height: 24rem; /* must match home loading intent height */
+}
+
+@media (max-width: 48rem) {
+  .sto-install-loading-wrapper {
+    min-height: unset;
+  }
+}
+
 .sto-install-loading {
   display: flex;
   flex-direction: row;
   justify-content: center;
+  align-items: center;
   padding: 1rem 0;
+  height: 100%;
 }
 
 .sto-install-terms {

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -5,7 +5,11 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
-import { App } from '../src/ducks/components/App'
+import {
+  App,
+  mapStateToProps,
+  mapDispatchToProps
+} from '../src/ducks/components/App'
 
 describe('App component only', () => {
   it('should be mounted correctly', () => {
@@ -13,5 +17,10 @@ describe('App component only', () => {
     const component = shallow(<App initApp={initApp} />).getElement()
     expect(component).toMatchSnapshot()
     expect(initApp.mock.calls.length).toBe(1)
+  })
+
+  it('should export mapStateToProps and mapDispatchToProps to allow customization', () => {
+    expect(typeof mapStateToProps).toBe('function')
+    expect(typeof mapDispatchToProps).toBe('function')
   })
 })

--- a/test/ducks/apps/__snapshots__/index.spec.js.snap
+++ b/test/ducks/apps/__snapshots__/index.spec.js.snap
@@ -28,6 +28,7 @@ Array [
         "icon": "<svg></svg>",
         "installed": false,
         "isInRegistry": true,
+        "label": 2,
         "links": Object {
           "icon": "/registry/konnector-bouilligue/0.1.0/icon",
         },
@@ -58,6 +59,7 @@ Array [
         "icon": "<svg></svg>",
         "installed": false,
         "isInRegistry": true,
+        "label": 1,
         "links": Object {
           "icon": "/registry/konnector-trinlane/0.1.0/icon",
         },
@@ -99,6 +101,7 @@ Array [
         "icon": "<svg></svg>",
         "installed": false,
         "isInRegistry": true,
+        "label": 1,
         "links": Object {
           "icon": "/registry/photos/3.0.0/icon",
         },
@@ -133,6 +136,7 @@ Array [
         "icon": "<svg></svg>",
         "installed": false,
         "isInRegistry": true,
+        "label": 4,
         "links": Object {
           "icon": "/registry/tasky/1.0.0/icon",
         },
@@ -188,6 +192,7 @@ Array [
       "icon": "<svg></svg>",
       "installed": true,
       "isInRegistry": true,
+      "label": 1,
       "links": Object {
         "icon": "/registry/collect/3.0.0/icon",
       },
@@ -250,6 +255,7 @@ Array [
       "icon": "<svg></svg>",
       "installed": false,
       "isInRegistry": true,
+      "label": 2,
       "links": Object {
         "icon": "/registry/konnector-bouilligue/0.1.0/icon",
       },

--- a/test/ducks/apps/__snapshots__/reducers.spec.js.snap
+++ b/test/ducks/apps/__snapshots__/reducers.spec.js.snap
@@ -13,6 +13,7 @@ Array [
     "icon": "<svg></svg>",
     "installed": true,
     "isInRegistry": true,
+    "label": 1,
     "name": "Collect",
     "name_prefix": "Cozy",
     "permissions": Object {

--- a/test/ducks/apps/_mockApps.js
+++ b/test/ducks/apps/_mockApps.js
@@ -4,6 +4,7 @@ export const apps = [
     slug: 'collect',
     name: 'Collect',
     editor: 'Cozy',
+    label: 1,
     name_prefix: 'Cozy',
     categories: ['cozy'],
     developer: { name: 'Cozy' },

--- a/test/ducks/apps/_mockPKonnectorTrinlaneRegistryVersion.js
+++ b/test/ducks/apps/_mockPKonnectorTrinlaneRegistryVersion.js
@@ -3,6 +3,7 @@ export const KonnectorTrinlane = {
   editor: 'Cozy',
   type: 'konnector',
   version: '0.1.0',
+  label: 1,
   manifest: {
     name: 'Trinlane',
     slug: 'konnector-trinlane',

--- a/test/ducks/apps/_mockPhotosRegistryVersion.js
+++ b/test/ducks/apps/_mockPhotosRegistryVersion.js
@@ -2,6 +2,7 @@ export const Photos = {
   slug: 'photos',
   editor: 'Cozy',
   type: 'webapp',
+  label: 1,
   version: '3.0.0',
   manifest: {
     name: 'Photos',

--- a/test/ducks/apps/_mockRegistryAppsResponse.js
+++ b/test/ducks/apps/_mockRegistryAppsResponse.js
@@ -5,6 +5,7 @@ export const RegistryAppsResponse = {
       slug: 'collect',
       type: 'webapp',
       editor: 'Cozy',
+      label: 1,
       versions: {
         stable: ['3.0.0'],
         beta: ['3.0.0'],
@@ -42,6 +43,7 @@ export const RegistryAppsResponse = {
       slug: 'devonly',
       editor: 'Cozy',
       type: 'webapp',
+      label: 3,
       versions: {
         stable: [],
         beta: [],
@@ -71,6 +73,7 @@ export const RegistryAppsResponse = {
       slug: 'konnector-bouilligue',
       editor: 'Cozy',
       type: 'konnector',
+      label: 2,
       versions: {
         stable: ['0.1.0'],
         beta: ['0.1.0'],
@@ -95,6 +98,7 @@ export const RegistryAppsResponse = {
       slug: 'konnector-trinlane',
       editor: 'Blibli',
       type: 'konnector',
+      label: 1,
       versions: {
         stable: ['0.1.0'],
         beta: ['0.1.0'],
@@ -126,6 +130,7 @@ export const RegistryAppsResponse = {
       slug: 'photos',
       type: 'webapp',
       editor: 'Cozy',
+      label: 1,
       versions: {
         stable: ['3.0.0'],
         beta: ['3.0.0'],
@@ -157,6 +162,7 @@ export const RegistryAppsResponse = {
       slug: 'tasky',
       type: 'webapp',
       editor: 'vestrejail',
+      label: 4,
       versions: {
         stable: ['1.0.0'],
         beta: ['1.0.0'],

--- a/test/ducks/apps/components/__snapshots__/appInstallation.spec.js.snap
+++ b/test/ducks/apps/components/__snapshots__/appInstallation.spec.js.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AppInstallation component should install automatically the app if the label is skippable and render the loading modal 1`] = `
+<React.Fragment>
+  <ModalContent
+    className="sto-install-loading-wrapper"
+  >
+    <div
+      className="sto-install-loading"
+    >
+      <Wrapper
+        size="xxlarge"
+      />
+    </div>
+  </ModalContent>
+</React.Fragment>
+`;
+
+exports[`AppInstallation component should not install automatically the app if the label is not skippable and render the permissions modal 1`] = `
+<React.Fragment>
+  <ModalHeader
+    title="Data usage"
+  />
+  <ModalContent />
+  <ModalFooter
+    className="sto-install-footer"
+  >
+    <div
+      className="sto-install-controls"
+    >
+      <DefaultButton
+        className="u-mh-half"
+        disabled={false}
+        extension="full"
+        label="Cancel"
+        onClick={[MockFunction]}
+        theme="secondary"
+      />
+      <DefaultButton
+        busy={false}
+        className="u-mh-half"
+        extension="full"
+        label="Install"
+        onClick={[Function]}
+        theme="primary"
+      />
+    </div>
+  </ModalFooter>
+</React.Fragment>
+`;

--- a/test/ducks/apps/components/__snapshots__/appsSection.spec.js.snap
+++ b/test/ducks/apps/components/__snapshots__/appsSection.spec.js.snap
@@ -23,6 +23,7 @@ exports[`AppsSection component should be rendered correctly with apps list, subt
           "icon": "<svg></svg>",
           "installed": true,
           "isInRegistry": true,
+          "label": 1,
           "name": "Collect",
           "name_prefix": "Cozy",
           "permissions": Object {

--- a/test/ducks/apps/components/__snapshots__/discover.spec.js.snap
+++ b/test/ducks/apps/components/__snapshots__/discover.spec.js.snap
@@ -24,6 +24,7 @@ exports[`Discover component should be rendered correctly with apps 1`] = `
               "icon": "<svg></svg>",
               "installed": true,
               "isInRegistry": true,
+              "label": 1,
               "name": "Collect",
               "name_prefix": "Cozy",
               "permissions": Object {
@@ -195,6 +196,7 @@ exports[`Discover component should be rendered correctly with apps 1`] = `
               "icon": "<svg></svg>",
               "installed": true,
               "isInRegistry": true,
+              "label": 1,
               "name": "Collect",
               "name_prefix": "Cozy",
               "permissions": Object {
@@ -376,6 +378,7 @@ exports[`Discover component should be rendered correctly with apps 1`] = `
           "icon": "<svg></svg>",
           "installed": true,
           "isInRegistry": true,
+          "label": 1,
           "name": "Collect",
           "name_prefix": "Cozy",
           "permissions": Object {
@@ -564,6 +567,7 @@ exports[`Discover component should be rendered correctly with apps and URL searc
               "icon": "<svg></svg>",
               "installed": true,
               "isInRegistry": true,
+              "label": 1,
               "name": "Collect",
               "name_prefix": "Cozy",
               "permissions": Object {
@@ -735,6 +739,7 @@ exports[`Discover component should be rendered correctly with apps and URL searc
               "icon": "<svg></svg>",
               "installed": true,
               "isInRegistry": true,
+              "label": 1,
               "name": "Collect",
               "name_prefix": "Cozy",
               "permissions": Object {
@@ -826,6 +831,7 @@ exports[`Discover component should be rendered correctly with apps and URL searc
           "icon": "<svg></svg>",
           "installed": true,
           "isInRegistry": true,
+          "label": 1,
           "name": "Collect",
           "name_prefix": "Cozy",
           "permissions": Object {
@@ -982,6 +988,7 @@ exports[`Discover component should use BarCenter from cozy-bar in mobile view on
               "icon": "<svg></svg>",
               "installed": true,
               "isInRegistry": true,
+              "label": 1,
               "name": "Collect",
               "name_prefix": "Cozy",
               "permissions": Object {
@@ -1153,6 +1160,7 @@ exports[`Discover component should use BarCenter from cozy-bar in mobile view on
               "icon": "<svg></svg>",
               "installed": true,
               "isInRegistry": true,
+              "label": 1,
               "name": "Collect",
               "name_prefix": "Cozy",
               "permissions": Object {
@@ -1334,6 +1342,7 @@ exports[`Discover component should use BarCenter from cozy-bar in mobile view on
           "icon": "<svg></svg>",
           "installed": true,
           "isInRegistry": true,
+          "label": 1,
           "name": "Collect",
           "name_prefix": "Cozy",
           "permissions": Object {

--- a/test/ducks/apps/components/__snapshots__/myApplications.spec.js.snap
+++ b/test/ducks/apps/components/__snapshots__/myApplications.spec.js.snap
@@ -24,6 +24,7 @@ exports[`MyApplications component should be rendered correctly if apps uninstall
               "icon": "<svg></svg>",
               "installed": true,
               "isInRegistry": true,
+              "label": 1,
               "name": "Collect",
               "name_prefix": "Cozy",
               "permissions": Object {
@@ -165,6 +166,7 @@ exports[`MyApplications component should be rendered correctly if apps uninstall
               "icon": "<svg></svg>",
               "installed": true,
               "isInRegistry": true,
+              "label": 1,
               "name": "Collect",
               "name_prefix": "Cozy",
               "permissions": Object {
@@ -315,6 +317,7 @@ exports[`MyApplications component should be rendered correctly if apps uninstall
           "icon": "<svg></svg>",
           "installed": true,
           "isInRegistry": true,
+          "label": 1,
           "name": "Collect",
           "name_prefix": "Cozy",
           "permissions": Object {
@@ -473,6 +476,7 @@ exports[`MyApplications component should be rendered correctly with apps and URL
               "icon": "<svg></svg>",
               "installed": true,
               "isInRegistry": true,
+              "label": 1,
               "name": "Collect",
               "name_prefix": "Cozy",
               "permissions": Object {
@@ -614,6 +618,7 @@ exports[`MyApplications component should be rendered correctly with apps and URL
               "icon": "<svg></svg>",
               "installed": true,
               "isInRegistry": true,
+              "label": 1,
               "name": "Collect",
               "name_prefix": "Cozy",
               "permissions": Object {
@@ -700,6 +705,7 @@ exports[`MyApplications component should be rendered correctly with apps and URL
           "icon": "<svg></svg>",
           "installed": true,
           "isInRegistry": true,
+          "label": 1,
           "name": "Collect",
           "name_prefix": "Cozy",
           "permissions": Object {
@@ -851,6 +857,7 @@ exports[`MyApplications component should use BarCenter from cozy-bar in mobile v
               "icon": "<svg></svg>",
               "installed": true,
               "isInRegistry": true,
+              "label": 1,
               "name": "Collect",
               "name_prefix": "Cozy",
               "permissions": Object {
@@ -992,6 +999,7 @@ exports[`MyApplications component should use BarCenter from cozy-bar in mobile v
               "icon": "<svg></svg>",
               "installed": true,
               "isInRegistry": true,
+              "label": 1,
               "name": "Collect",
               "name_prefix": "Cozy",
               "permissions": Object {
@@ -1142,6 +1150,7 @@ exports[`MyApplications component should use BarCenter from cozy-bar in mobile v
           "icon": "<svg></svg>",
           "installed": true,
           "isInRegistry": true,
+          "label": 1,
           "name": "Collect",
           "name_prefix": "Cozy",
           "permissions": Object {

--- a/test/ducks/apps/components/__snapshots__/sections.spec.js.snap
+++ b/test/ducks/apps/components/__snapshots__/sections.spec.js.snap
@@ -68,6 +68,7 @@ exports[`AppsSection component should be rendered correctly with apps list, subt
               "icon": "<svg></svg>",
               "installed": true,
               "isInRegistry": true,
+              "label": 1,
               "name": "Collect",
               "name_prefix": "Cozy",
               "permissions": Object {

--- a/test/ducks/apps/components/appInstallation.spec.js
+++ b/test/ducks/apps/components/appInstallation.spec.js
@@ -1,0 +1,65 @@
+'use strict'
+
+/* eslint-env jest */
+
+import React from 'react'
+import { shallow } from 'enzyme'
+import flags from 'cozy-flags'
+
+import { tMock } from '../../../jestLib/I18n'
+import { AppInstallation } from 'ducks/apps/components/AppInstallation'
+import CTS from 'config/constants'
+
+import mockRegistryApp from '../_mockPhotosRegistryVersion'
+
+describe('AppInstallation component', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    jest.spyOn(AppInstallation.prototype, 'installApp')
+  })
+  afterEach(() => {
+    AppInstallation.prototype.installApp.mockRestore()
+  })
+
+  it('should install automatically the app if the label is skippable and render the loading modal', () => {
+    flags('skip-low-permissions', true)
+    const mockApp = Object.assign({}, mockRegistryApp, {
+      label: CTS.default.authorizedLabelLimit
+    })
+    const mockInstallProp = jest.fn(() => Promise.resolve())
+    const component = shallow(
+      <AppInstallation
+        t={tMock}
+        appSlug={mockApp.slug}
+        app={mockApp}
+        onCancel={jest.fn()}
+        installApp={mockInstallProp}
+      />
+    )
+    expect(mockInstallProp).toHaveBeenCalledTimes(1)
+    expect(AppInstallation.prototype.installApp).toHaveBeenCalledTimes(1)
+    expect(component.getElement()).toMatchSnapshot()
+    flags('skip-low-permissions', false)
+  })
+
+  it('should not install automatically the app if the label is not skippable and render the permissions modal', () => {
+    flags('skip-low-permissions', true)
+    const mockApp = Object.assign({}, mockRegistryApp, {
+      label: CTS.default.authorizedLabelLimit + 1
+    })
+    const mockInstallProp = jest.fn(() => Promise.resolve())
+    const component = shallow(
+      <AppInstallation
+        t={tMock}
+        appSlug={mockApp.slug}
+        app={mockApp}
+        onCancel={jest.fn()}
+        installApp={mockInstallProp}
+      />
+    )
+    expect(mockInstallProp).not.toHaveBeenCalled()
+    expect(AppInstallation.prototype.installApp).not.toHaveBeenCalled()
+    expect(component.getElement()).toMatchSnapshot()
+    flags('skip-low-permissions', false)
+  })
+})

--- a/test/ducks/apps/components/applicationPage/__snapshots__/header.spec.js.snap
+++ b/test/ducks/apps/components/applicationPage/__snapshots__/header.spec.js.snap
@@ -11,6 +11,7 @@ exports[`ApplicationPage header component should be rendered correctly provided 
       app={
         Object {
           "editor": "Cozy",
+          "label": 1,
           "manifest": Object {
             "categories": Array [
               "cozy",
@@ -313,6 +314,7 @@ exports[`ApplicationPage header component should be rendered correctly provided 
       app={
         Object {
           "editor": "Cozy",
+          "label": 1,
           "manifest": Object {
             "categories": Array [
               "transport",

--- a/test/ducks/apps/components/applicationRouting/__snapshots__/index.spec.js.snap
+++ b/test/ducks/apps/components/applicationRouting/__snapshots__/index.spec.js.snap
@@ -18,6 +18,7 @@ ShallowWrapper {
           "icon": "<svg></svg>",
           "installed": true,
           "isInRegistry": true,
+          "label": 1,
           "name": "Collect",
           "name_prefix": "Cozy",
           "permissions": Object {
@@ -249,6 +250,7 @@ ShallowWrapper {
           "icon": "<svg></svg>",
           "installed": true,
           "isInRegistry": true,
+          "label": 1,
           "name": "Collect",
           "name_prefix": "Cozy",
           "permissions": Object {

--- a/test/ducks/apps/components/applicationRouting/__snapshots__/permissionsRoute.spec.js.snap
+++ b/test/ducks/apps/components/applicationRouting/__snapshots__/permissionsRoute.spec.js.snap
@@ -14,6 +14,7 @@ exports[`PermissionsRoute component should display permissions modal if app foun
       "icon": "<svg></svg>",
       "installed": true,
       "isInRegistry": true,
+      "label": 1,
       "name": "Collect",
       "name_prefix": "Cozy",
       "permissions": Object {

--- a/test/lib/__snapshots__/getFilteredAppsFromSearch.spec.js.snap
+++ b/test/lib/__snapshots__/getFilteredAppsFromSearch.spec.js.snap
@@ -13,6 +13,7 @@ Array [
     "icon": "<svg></svg>",
     "installed": true,
     "isInRegistry": true,
+    "label": 1,
     "name": "Collect",
     "name_prefix": "Cozy",
     "permissions": Object {
@@ -123,6 +124,7 @@ Array [
     "icon": "<svg></svg>",
     "installed": true,
     "isInRegistry": true,
+    "label": 1,
     "name": "Collect",
     "name_prefix": "Cozy",
     "permissions": Object {
@@ -233,6 +235,7 @@ Array [
     "icon": "<svg></svg>",
     "installed": true,
     "isInRegistry": true,
+    "label": 1,
     "name": "Collect",
     "name_prefix": "Cozy",
     "permissions": Object {
@@ -320,6 +323,7 @@ Array [
     "icon": "<svg></svg>",
     "installed": true,
     "isInRegistry": true,
+    "label": 1,
     "name": "Collect",
     "name_prefix": "Cozy",
     "permissions": Object {
@@ -528,6 +532,7 @@ Array [
     "icon": "<svg></svg>",
     "installed": true,
     "isInRegistry": true,
+    "label": 1,
     "name": "Collect",
     "name_prefix": "Cozy",
     "permissions": Object {

--- a/test/lib/__snapshots__/helpers.spec.js.snap
+++ b/test/lib/__snapshots__/helpers.spec.js.snap
@@ -14,6 +14,7 @@ Object {
       "icon": "<svg></svg>",
       "installed": true,
       "isInRegistry": true,
+      "label": 1,
       "name": "Collect",
       "name_prefix": "Cozy",
       "permissions": Object {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3355,6 +3355,13 @@ cozy-device-helper@^1.4.4:
   dependencies:
     lodash "4.17.10"
 
+cozy-flags@1.5.9:
+  version "1.5.9"
+  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-1.5.9.tgz#5a1726a329e86e6498bf629cf7508d4632a36e3b"
+  integrity sha512-so2PDfBTT4770jG8cXDXs9wUd1kTp6Wnf/IfnONaJKZmjqFf3THJ8cK6jN6zkgLZeDGJbdAutd66g8/XnoOhhw==
+  dependencies:
+    detect-node "2.0.4"
+
 cozy-realtime@2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-2.0.7.tgz#1ca40806e4a3e752bf1d6ea4f8a761a8eaa123d2"
@@ -3892,7 +3899,7 @@ detect-newline@^2.1.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
-detect-node@^2.0.3:
+detect-node@2.0.4, detect-node@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
   integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==


### PR DESCRIPTION
Allow to skip permissions when installing app or konnectors when the label is below a configurable `authorizedLabelLimit` number