### PR TITLE
fix(SmallAppItem): Set text color

### DIFF
--- a/src/styles/smallAppItem.css
+++ b/src/styles/smallAppItem.css
@@ -23,6 +23,7 @@
   margin-right: .75rem;
   overflow: hidden;
   transition: .15s ease all;
+  color: var(--black);
 }
 
 .sto-small-app-item:hover,


### PR DESCRIPTION
On systems with a dark theme, elements such as buttons or inputs have a
white text color. It was preventing the user from seeing the apps names
here, since `SmallAppItem`s are `button`s. By setting the color to
black, we avoid this issue.

| Before | After |
|--------|-------|
|![image](https://user-images.githubusercontent.com/1606068/55315853-828da480-546d-11e9-9cee-ad004196f722.png)|![image](https://user-images.githubusercontent.com/1606068/55315877-90432a00-546d-11e9-8698-480ef93bcd04.png)|

For information, my particular setup is Ubuntu 18.10 with dark theme enabled.

