### PR TITLE
wip: Pass provided queries with path redirecting

### DIFF
--- a/src/ducks/apps/components/ApplicationRouting/index.jsx
+++ b/src/ducks/apps/components/ApplicationRouting/index.jsx
@@ -22,7 +22,8 @@ export class ApplicationRouting extends Component {
   }
 
   redirectTo = target => {
-    this.props.history.replace(target)
+    const { history, location } = this.props
+    history.replace(target + location.search)
     return null
   }
 

--- a/test/ducks/apps/components/applicationRouting/__snapshots__/index.spec.js.snap
+++ b/test/ducks/apps/components/applicationRouting/__snapshots__/index.spec.js.snap
@@ -380,6 +380,11 @@ ShallowWrapper {
       ]
     }
     isFetching={false}
+    location={
+      Object {
+        "search": "",
+      }
+    }
     parent="myapps"
     uninstallApp={[MockFunction mockUninstallApp]}
   />,

--- a/test/ducks/apps/components/applicationRouting/index.spec.js
+++ b/test/ducks/apps/components/applicationRouting/index.spec.js
@@ -24,6 +24,7 @@ const getMockProps = (
   isFetching,
   parent,
   history: { push: jest.fn(), replace: jest.fn() },
+  location: { search: '' },
   uninstallApp: jest.fn().mockName('mockUninstallApp'),
   installApp: jest.fn().mockName('mockInstallApp')
 })


### PR DESCRIPTION
Allow to keep the URL queries when navigating within the app