### PR TITLE
feat: Update cozy-client and cozy-realtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
   "dependencies": {
     "cozy-bar": "6.1.2",
     "cozy-client": "6.31.1",
-    "cozy-client-js": "0.15.1",
     "cozy-flags": "1.6.1",
     "cozy-interapp": "^0.4.5",
     "cozy-logger": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "cozy-client": "6.31.1",
     "cozy-client-js": "0.15.1",
     "cozy-flags": "1.6.1",
+    "cozy-interapp": "^0.4.5",
     "cozy-logger": "1.3.1",
     "cozy-realtime": "^3.0.1",
     "cozy-ui": "19.35.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "cozy-client-js": "0.15.1",
     "cozy-flags": "1.6.1",
     "cozy-logger": "1.3.1",
-    "cozy-realtime": "2.0.8",
+    "cozy-realtime": "^3.0.1",
     "cozy-ui": "19.35.0",
     "emoji-js": "3.4.1",
     "eslint-config-prettier": "4.2.0",

--- a/src/ducks/apps/client-helpers.js
+++ b/src/ducks/apps/client-helpers.js
@@ -1,3 +1,5 @@
+import { APP_TYPE } from './constants'
+
 /**
  * Fetch at most 200 apps from the channel
  *
@@ -11,6 +13,19 @@ export const fetchAppsFromChannel = (client, channel, filter) => {
     'GET',
     `/registry?limit=200&versionsChannel=${channel}&latestChannelVersion=${channel}${filterParam}`
   )
+}
+
+/**
+ * Fetch user apps or konnectors.
+ * Adds type property in attributes from stack
+ */
+export const fetchUserApps = async (client, type) => {
+  const route = type === APP_TYPE.KONNECTOR ? '/konnectors/' : '/apps/'
+  const { data } = await client.stackClient.fetchJSON('GET', route)
+  return data.map(x => {
+    x.attributes.type = type
+    return x
+  })
 }
 
 export const fetchAppOrKonnector = (client, doctype, slug) => {

--- a/src/ducks/apps/client-helpers.js
+++ b/src/ducks/apps/client-helpers.js
@@ -1,0 +1,14 @@
+/**
+ * Fetch at most 200 apps from the channel
+ *
+ * Optional filter can be given
+ */
+export const fetchAppsFromChannel = (client, channel, filter) => {
+  let filterParam = ''
+  // TODO do it with URL or queryParams
+  if (filter) filterParam = `&filter[type]=${filter}`
+  return client.stackClient.fetchJSON(
+    'GET',
+    `/registry?limit=200&versionsChannel=${channel}&latestChannelVersion=${channel}${filterParam}`
+  )
+}

--- a/src/ducks/apps/client-helpers.js
+++ b/src/ducks/apps/client-helpers.js
@@ -12,3 +12,12 @@ export const fetchAppsFromChannel = (client, channel, filter) => {
     `/registry?limit=200&versionsChannel=${channel}&latestChannelVersion=${channel}${filterParam}`
   )
 }
+
+export const fetchAppOrKonnector = (client, doctype, slug) => {
+  // FIXME: hack to handle node type from stack for the konnectors
+  const route =
+    doctype === APP_TYPE.KONNECTOR || doctype === 'node' ? 'konnectors' : 'apps'
+  return client.stackClient
+    .fetchJSON('GET', `/${route}/${slug}`)
+    .then(x => x.data)
+}

--- a/src/ducks/apps/components/AppInstallation.jsx
+++ b/src/ducks/apps/components/AppInstallation.jsx
@@ -18,6 +18,7 @@ import Checkbox from 'cozy-ui/react/Checkbox'
 import { getTranslatedManifestProperty } from 'lib/helpers'
 import { hasPendingUpdate } from 'ducks/apps/appStatus'
 import storeConfig from 'config'
+import compose from 'lodash/flowRight'
 
 import { APP_TYPE, getAppBySlug, installAppFromRegistry } from 'ducks/apps'
 
@@ -208,7 +209,10 @@ const mapDispatchToProps = dispatch => ({
     dispatch(installAppFromRegistry(app, channel, isUpdate))
 })
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(translate()(AppInstallation))
+export default compose(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  ),
+  translate()
+)(AppInstallation)

--- a/src/ducks/apps/components/AppInstallation.jsx
+++ b/src/ducks/apps/components/AppInstallation.jsx
@@ -21,6 +21,7 @@ import storeConfig from 'config'
 import compose from 'lodash/flowRight'
 
 import { APP_TYPE, getAppBySlug, installAppFromRegistry } from 'ducks/apps'
+import { withClient } from 'cozy-client'
 
 const shouldSkipPermissions = app =>
   flags('skip-low-permissions') &&
@@ -204,12 +205,13 @@ const mapStateToProps = (state, ownProps) => ({
   installError: state.apps.actionError
 })
 
-const mapDispatchToProps = dispatch => ({
+const mapDispatchToProps = (dispatch, ownProps) => ({
   installApp: (app, channel, isUpdate) =>
-    dispatch(installAppFromRegistry(app, channel, isUpdate))
+    dispatch(installAppFromRegistry(ownProps.client, app, channel, isUpdate))
 })
 
 export default compose(
+  withClient,
   connect(
     mapStateToProps,
     mapDispatchToProps

--- a/src/ducks/apps/components/ApplicationPage/Details.jsx
+++ b/src/ducks/apps/components/ApplicationPage/Details.jsx
@@ -1,8 +1,8 @@
 import React, { Component } from 'react'
 import { withRouter } from 'react-router-dom'
 
+import { withClient } from 'cozy-client'
 import { translate } from 'cozy-ui/react/I18n'
-
 import { Button } from 'cozy-ui/react/Button'
 import Icon from 'cozy-ui/react/Icon'
 import Toggle from 'cozy-ui/react/Toggle'
@@ -50,7 +50,7 @@ export class Details extends Component {
       stateUpdate.displayBetaChannel = true
     }
     if (!this.state.displayDevChannel) {
-      const context = await getContext()
+      const context = await getContext(this.props.client)
       if (context && context.attributes && context.attributes.debug) {
         stateUpdate.displayDevChannel = true
       }
@@ -218,4 +218,4 @@ export class Details extends Component {
   }
 }
 
-export default withRouter(translate()(Details))
+export default withClient(withRouter(translate()(Details)))

--- a/src/ducks/apps/components/ApplicationPage/Header.jsx
+++ b/src/ducks/apps/components/ApplicationPage/Header.jsx
@@ -2,6 +2,7 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 import { connect } from 'react-redux'
+import compose from 'lodash/flowRight'
 
 import AppIcon from 'cozy-ui/react/AppIcon'
 import Button from 'cozy-ui/react/Button'
@@ -101,6 +102,10 @@ export const Header = ({
   )
 }
 
-export default connect(state => ({
-  isInstalling: state.apps.isInstalling
-}))(withBreakpoints()(translate()(Header)))
+export default compose(
+  connect(state => ({
+    isInstalling: state.apps.isInstalling
+  })),
+  withBreakpoints(),
+  translate()
+)(Header)

--- a/src/ducks/apps/components/ApplicationPage/Header.jsx
+++ b/src/ducks/apps/components/ApplicationPage/Header.jsx
@@ -1,4 +1,3 @@
-/* global cozy */
 import React from 'react'
 import { Link } from 'react-router-dom'
 import { connect } from 'react-redux'
@@ -8,6 +7,8 @@ import AppIcon from 'cozy-ui/react/AppIcon'
 import Button from 'cozy-ui/react/Button'
 import { translate } from 'cozy-ui/react/I18n'
 import withBreakpoints from 'cozy-ui/react/helpers/withBreakpoints'
+import Intents from 'cozy-interapp'
+import { withClient } from 'cozy-client'
 
 import cozySmileIcon from 'assets/icons/icon-cozy-smile.svg'
 import AsyncButton from 'ducks/components/AsyncButton'
@@ -27,7 +28,8 @@ export const Header = ({
   description,
   parent,
   isInstalling,
-  breakpoints = {}
+  breakpoints = {},
+  client
 }) => {
   const { slug, installed, type, related, uninstallable } = app
   const { isMobile } = breakpoints
@@ -51,11 +53,12 @@ export const Header = ({
         {isInstalledAndNothingToReport(app) && !isCurrentAppInstalling ? (
           isKonnector ? (
             <AsyncButton
-              asyncAction={() =>
-                cozy.client.intents.redirect('io.cozy.accounts', {
+              asyncAction={() => {
+                const intents = new Intents({ client })
+                return intents.redirect('io.cozy.accounts', {
                   konnector: app.slug
                 })
-              }
+              }}
               className="c-btn"
               icon="openwith"
               label={t('app_page.konnector.open')}
@@ -107,5 +110,6 @@ export default compose(
     isInstalling: state.apps.isInstalling
   })),
   withBreakpoints(),
-  translate()
+  translate(),
+  withClient
 )(Header)

--- a/src/ducks/apps/components/ChannelModal.jsx
+++ b/src/ducks/apps/components/ChannelModal.jsx
@@ -5,6 +5,8 @@ import { translate } from 'cozy-ui/react/I18n'
 import FocusTrap from 'focus-trap-react'
 import Portal from 'cozy-ui/react/Portal'
 import PropTypes from 'prop-types'
+import compose from 'lodash/flowRight'
+import { withClient } from 'cozy-client'
 
 import AppInstallation from 'ducks/apps/components/AppInstallation'
 import getChannel from 'lib/getChannelFromSource'
@@ -93,7 +95,9 @@ ChannelModal.propTypes = {
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
   fetchLatestApp: (app, channel) =>
-    dispatch(fetchLatestApp(ownProps.lang, app.slug, channel, app)),
+    dispatch(
+      fetchLatestApp(ownProps.client, ownProps.lang, app.slug, channel, app)
+    ),
   restoreAppIfSaved: () => dispatch(restoreAppIfSaved())
 })
 
@@ -101,9 +105,11 @@ const mapStateToProps = (state, ownProps) => ({
   app: getAppBySlug(state, ownProps.appSlug)
 })
 
-export default translate()(
+export default compose(
+  withClient,
+  translate(),
   connect(
     mapStateToProps,
     mapDispatchToProps
-  )(ChannelModal)
-)
+  )
+)(ChannelModal)

--- a/src/ducks/apps/components/ChannelModal.jsx
+++ b/src/ducks/apps/components/ChannelModal.jsx
@@ -1,16 +1,16 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import Modal from 'cozy-ui/react/Modal'
-import { translate } from 'cozy-ui/react/I18n'
-import FocusTrap from 'focus-trap-react'
 import Portal from 'cozy-ui/react/Portal'
 import PropTypes from 'prop-types'
 import compose from 'lodash/flowRight'
+
+import FocusTrap from 'focus-trap-react'
+import Modal from 'cozy-ui/react/Modal'
+import { translate } from 'cozy-ui/react/I18n'
 import { withClient } from 'cozy-client'
 
 import AppInstallation from 'ducks/apps/components/AppInstallation'
 import getChannel from 'lib/getChannelFromSource'
-
 import { fetchLatestApp, getAppBySlug, restoreAppIfSaved } from 'ducks/apps'
 
 export class ChannelModal extends Component {

--- a/src/ducks/apps/components/ConfigureModal.jsx
+++ b/src/ducks/apps/components/ConfigureModal.jsx
@@ -3,10 +3,11 @@ import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import IntentModal from 'cozy-ui/react/IntentModal'
 import withBreakpoints from 'cozy-ui/react/helpers/withBreakpoints'
-
+import { withClient } from 'cozy-client'
 import { getAppBySlug } from 'ducks/apps'
-
+import Intents from 'cozy-interapp'
 import { APP_TYPE } from 'ducks/apps'
+import compose from 'lodash/flowRight'
 
 export class ConfigureModal extends Component {
   constructor(props) {
@@ -22,11 +23,17 @@ export class ConfigureModal extends Component {
     }
   }
 
+  componentWillMount() {
+    const { client } = this.props
+    this.intents = new Intents({ client })
+  }
+
   render() {
     const { app, dismissAction, onSuccess, breakpoints = {} } = this.props
     const { isMobile } = breakpoints
     return (
       <IntentModal
+        create={this.intents.create.bind(this.intents)}
         action="CREATE"
         doctype="io.cozy.accounts"
         options={{ slug: app.slug }}
@@ -54,4 +61,8 @@ const mapStateToProps = (state, ownProps) => ({
   app: getAppBySlug(state, ownProps.appSlug)
 })
 
-export default connect(mapStateToProps)(withBreakpoints()(ConfigureModal))
+export default compose(
+  connect(mapStateToProps),
+  withBreakpoints(),
+  withClient
+)(ConfigureModal)

--- a/src/ducks/apps/components/InstallModal.jsx
+++ b/src/ducks/apps/components/InstallModal.jsx
@@ -5,7 +5,8 @@ import Modal from 'cozy-ui/react/Modal'
 import FocusTrap from 'focus-trap-react'
 import { translate } from 'cozy-ui/react/I18n'
 import Portal from 'cozy-ui/react/Portal'
-
+import { withClient } from 'cozy-client'
+import compose from 'lodash/flowRight'
 import AppInstallation from 'ducks/apps/components/AppInstallation'
 import { hasPendingUpdate } from 'ducks/apps/appStatus'
 import { fetchLatestApp, restoreAppIfSaved } from 'ducks/apps'
@@ -74,13 +75,17 @@ InstallModal.propTypes = {
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
   fetchLatestApp: app =>
-    dispatch(fetchLatestApp(ownProps.lang, app.slug, undefined, app)),
+    dispatch(
+      fetchLatestApp(ownProps.client, ownProps.lang, app.slug, undefined, app)
+    ),
   restoreAppIfSaved: () => dispatch(restoreAppIfSaved())
 })
 
-export default translate()(
+export default compose(
+  withClient,
+  translate(),
   connect(
     null,
     mapDispatchToProps
-  )(InstallModal)
-)
+  )
+)(InstallModal)

--- a/src/ducks/apps/components/UninstallModal.jsx
+++ b/src/ducks/apps/components/UninstallModal.jsx
@@ -11,6 +11,7 @@ import Button from 'cozy-ui/react/Button'
 import { getAppBySlug, uninstallApp } from 'ducks/apps'
 import Modal, { ModalDescription, ModalFooter } from 'cozy-ui/react/Modal'
 import Portal from 'cozy-ui/react/Portal'
+import { withClient } from 'cozy-client'
 
 import ReactMarkdownWrapper from 'ducks/components/ReactMarkdownWrapper'
 
@@ -67,7 +68,8 @@ export class UninstallModal extends Component {
       isInstalling,
       dismissAction,
       t,
-      uninstallError
+      uninstallError,
+      client
     } = this.props
     const linkedAppError =
       uninstallError &&
@@ -83,7 +85,7 @@ export class UninstallModal extends Component {
           <ModalDescription>
             <ReactMarkdownWrapper
               source={t('app_modal.uninstall.description', {
-                cozyName: cozy.client._url.replace(/^\/\//, '')
+                cozyName: client.stackClient.uri.replace(/^\/\//, '')
               })}
             />
             {uninstallError && !linkedAppError && (
@@ -146,13 +148,14 @@ const mapStateToProps = (state, ownProps) => ({
   uninstallError: state.apps.actionError
 })
 
-const mapDispatchToProps = dispatch => ({
+const mapDispatchToProps = (dispatch, ownProps) => ({
   uninstallApp: app => {
-    return dispatch(uninstallApp(app))
+    return dispatch(uninstallApp(ownProps.client, app))
   }
 })
 
 export default compose(
+  withClient,
   connect(
     mapStateToProps,
     mapDispatchToProps

--- a/src/ducks/apps/components/UninstallModal.jsx
+++ b/src/ducks/apps/components/UninstallModal.jsx
@@ -26,6 +26,8 @@ export class UninstallModal extends Component {
     if (app && !app.installed) {
       onNotInstalled()
     }
+
+    this.handleUninstallApp = this.handleUninstallApp.bind(this)
   }
 
   componentDidUpdate = prevProps => {
@@ -39,7 +41,7 @@ export class UninstallModal extends Component {
     }
   }
 
-  uninstallApp = () => {
+  handleUninstallApp() {
     const { app, uninstallApp } = this.props
     uninstallApp(app)
   }
@@ -118,7 +120,7 @@ export class UninstallModal extends Component {
               disabled={isUninstalling || isInstalling || !!linkedAppError}
               theme="danger"
               icon="delete"
-              onClick={this.uninstallApp}
+              onClick={this.handleUninstallApp}
               label={t('app_modal.uninstall.uninstall')}
               extension="full"
               className="u-mh-half"

--- a/src/ducks/apps/components/UninstallModal.jsx
+++ b/src/ducks/apps/components/UninstallModal.jsx
@@ -1,4 +1,3 @@
-/* global cozy */
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
@@ -12,6 +11,7 @@ import { getAppBySlug, uninstallApp } from 'ducks/apps'
 import Modal, { ModalDescription, ModalFooter } from 'cozy-ui/react/Modal'
 import Portal from 'cozy-ui/react/Portal'
 import { withClient } from 'cozy-client'
+import Intents from 'cozy-interapp'
 
 import ReactMarkdownWrapper from 'ducks/components/ReactMarkdownWrapper'
 
@@ -51,7 +51,8 @@ export class UninstallModal extends Component {
     if (this.state.redirecting) return // don't toggle twice
     this.setState(() => ({ redirecting: true }))
     try {
-      await cozy.client.intents.redirect('io.cozy.settings', {
+      const intents = new Intents({ client: this.props.client })
+      await intents.redirect('io.cozy.settings', {
         step: 'connectedDevices'
       })
     } catch (error) {

--- a/src/ducks/apps/components/UninstallModal.jsx
+++ b/src/ducks/apps/components/UninstallModal.jsx
@@ -3,6 +3,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
 import PropTypes from 'prop-types'
+import compose from 'lodash/flowRight'
 
 import { translate } from 'cozy-ui/react/I18n'
 import Alerter from 'cozy-ui/react/Alerter'
@@ -149,7 +150,11 @@ const mapDispatchToProps = dispatch => ({
   }
 })
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(translate()(withRouter(UninstallModal)))
+export default compose(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  ),
+  translate(),
+  withRouter
+)(UninstallModal)

--- a/src/ducks/apps/constants.js
+++ b/src/ducks/apps/constants.js
@@ -1,0 +1,16 @@
+export const APP_TYPE = {
+  KONNECTOR: 'konnector',
+  WEBAPP: 'webapp'
+}
+
+export const REGISTRY_CHANNELS = {
+  DEV: 'dev',
+  BETA: 'beta',
+  STABLE: 'stable'
+}
+
+export const APP_STATE = {
+  READY: 'ready',
+  INSTALLING: 'installing',
+  ERRORED: 'errored'
+}

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -29,23 +29,11 @@ import {
   SAVE_APP
 } from './reducers'
 import { fetchAppsFromChannel, fetchAppOrKonnector } from './client-helpers'
+import { APP_TYPE, APP_STATE, REGISTRY_CHANNELS } from './constants'
 
-const APP_STATE = {
-  READY: 'ready',
-  INSTALLING: 'installing',
-  ERRORED: 'errored'
-}
-
-export const APP_TYPE = {
-  KONNECTOR: 'konnector',
-  WEBAPP: 'webapp'
-}
-
-export const REGISTRY_CHANNELS = {
-  DEV: 'dev',
-  BETA: 'beta',
-  STABLE: 'stable'
-}
+export { APP_STATE }
+export { APP_TYPE }
+export { REGISTRY_CHANNELS }
 
 const APPS_DOCTYPE = 'io.cozy.apps'
 const KONNECTORS_DOCTYPE = 'io.cozy.konnectors'

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -198,7 +198,7 @@ export function initAppIntent(lang, slug) {
   }
 }
 
-function onAppUpdate(appResponse) {
+function onAppUpdate(client, appResponse) {
   return async dispatch => {
     if (appResponse.state === APP_STATE.ERRORED) {
       const err = new Error('Error when installing the application')
@@ -211,7 +211,7 @@ function onAppUpdate(appResponse) {
         appResponse.type === APP_TYPE.KONNECTOR || appResponse.type === 'node'
           ? 'konnectors'
           : 'apps'
-      const appFromStack = await cozy.client.fetchJSON(
+      const appFromStack = await client.stackClient.fetchJSON(
         'GET',
         `/${route}/${appResponse.slug}`
       )
@@ -237,7 +237,7 @@ function onAppDelete(appResponse) {
 function initializeRealtime(client) {
   const realtime = new CozyRealtime({ cozyClient: client })
   return dispatch => {
-    const handleAppUpdate = app => dispatch(onAppUpdate(app))
+    const handleAppUpdate = app => dispatch(onAppUpdate(client, app))
     const handleAppDelete = app => dispatch(onAppDelete(app))
 
     for (let doctype of [APPS_DOCTYPE, KONNECTORS_DOCTYPE]) {

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -103,10 +103,10 @@ export function _sanitizeCategories(categoriesList) {
 }
 
 let contextCache
-export function getContext() {
+export function getContext(client) {
   return contextCache
     ? Promise.resolve(contextCache)
-    : cozy.client
+    : client.stackClient
         .fetchJSON('GET', '/settings/context')
         .then(context => {
           contextCache = context
@@ -119,6 +119,9 @@ export function getContext() {
           }
           return {}
         })
+}
+getContext.clearCache = () => {
+  contextCache = null
 }
 
 export function _getRegistryAssetsLinks(manifest, appVersion) {

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -254,9 +254,9 @@ function initializeRealtime(client) {
   }
 }
 
-async function _getInstalledInfos(app) {
+async function _getInstalledInfos(client, app) {
   try {
-    let installedApp = await cozy.client.fetchJSON(
+    let installedApp = await client.stackClient.fetchJSON(
       'GET',
       `/${app.type === APP_TYPE.WEBAPP ? 'apps' : 'konnectors'}/${app.slug}`
     )
@@ -302,7 +302,7 @@ export function fetchLatestApp(
     }
     try {
       const formattedApp = await getFormattedRegistryApp(client, app, channel)
-      formattedApp.installed = await _getInstalledInfos(app)
+      formattedApp.installed = await _getInstalledInfos(client, app)
       // dispatch the app only if we are still in fetching status
       // (meant that the fetch has not been cancelled by a RESTORE_APP action)
       if (getState().apps.isAppFetching) {

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -240,23 +240,17 @@ function initializeRealtime(client) {
     const handleAppUpdate = app => dispatch(onAppUpdate(app))
     const handleAppDelete = app => dispatch(onAppDelete(app))
 
-    try {
-      realtime.subscribe('create', APPS_DOCTYPE, handleAppUpdate)
-      realtime.subscribe('update', APPS_DOCTYPE, handleAppUpdate)
-      realtime.subscribe('delete', APPS_DOCTYPE, handleAppDelete)
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.warn(`Cannot initialize realtime for apps: ${error.message}`)
-    }
-    try {
-      realtime.subscribe('create', KONNECTORS_DOCTYPE, handleAppUpdate)
-      realtime.subscribe('update', KONNECTORS_DOCTYPE, handleAppUpdate)
-      realtime.subscribe('delete', KONNECTORS_DOCTYPE, handleAppDelete)
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `Cannot initialize realtime for konnectors: ${error.message}`
-      )
+    for (let doctype of [APPS_DOCTYPE, KONNECTORS_DOCTYPE]) {
+      try {
+        realtime.subscribe('created', doctype, handleAppUpdate)
+        realtime.subscribe('updated', doctype, handleAppUpdate)
+        realtime.subscribe('deleted', doctype, handleAppDelete)
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `Cannot initialize realtime for ${doctype}: ${error.message}`
+        )
+      }
     }
   }
 }

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -190,11 +190,11 @@ export function initApp(client, lang) {
 }
 
 // only on the app install intent initialisation
-export function initAppIntent(lang, slug) {
+export function initAppIntent(client, lang, slug) {
   return async dispatch => {
     dispatch({ type: LOADING_APP_INTENT })
-    dispatch(initializeRealtime())
-    return await dispatch(fetchLatestApp(lang, slug))
+    dispatch(initializeRealtime(client))
+    return await dispatch(fetchLatestApp(client, lang, slug))
   }
 }
 
@@ -276,6 +276,7 @@ export function restoreAppIfSaved() {
 }
 
 export function fetchLatestApp(
+  client,
   lang,
   slug,
   channel = DEFAULT_CHANNEL,
@@ -286,7 +287,8 @@ export function fetchLatestApp(
     dispatch({ type: FETCH_APP })
     let app = getState().apps.list.find(a => a.slug === slug)
     try {
-      app = await cozy.client.fetchJSON(
+      // TODO check if possible to do via fetchAppsFromChannel
+      app = await client.stackClient.fetchJSON(
         'GET',
         `/registry/${slug}?latestChannelVersion=${channel}`
       )

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -28,6 +28,7 @@ import {
   RESTORE_APP,
   SAVE_APP
 } from './reducers'
+import { fetchAppsFromChannel } from './client-helpers'
 
 const APP_STATE = {
   READY: 'ready',
@@ -470,14 +471,7 @@ export function fetchInstalledApps(client, lang, fetchingRegistry) {
 export function fetchRegistryApps(client, lang, channel = DEFAULT_CHANNEL) {
   return dispatch => {
     dispatch({ type: FETCH_APPS })
-    let filterParam = ''
-    if (storeConfig.filterAppType)
-      filterParam = `&filter[type]=${storeConfig.filterAppType}`
-    return client.stackClient
-      .fetchJSON(
-        'GET',
-        `/registry?limit=200&versionsChannel=${channel}&latestChannelVersion=${channel}${filterParam}`
-      )
+    return fetchAppsFromChannel(client, channel, storeConfig.filterAppType)
       .then(response => {
         const apps = response.data
           .filter(app => !config.notDisplayedApps.includes(app.slug))

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -28,7 +28,11 @@ import {
   RESTORE_APP,
   SAVE_APP
 } from './reducers'
-import { fetchAppsFromChannel, fetchAppOrKonnector } from './client-helpers'
+import {
+  fetchUserApps,
+  fetchAppsFromChannel,
+  fetchAppOrKonnector
+} from './client-helpers'
 import { APP_TYPE, APP_STATE, REGISTRY_CHANNELS } from './constants'
 
 export { APP_STATE }
@@ -390,23 +394,18 @@ export function fetchInstalledApps(client, lang, fetchingRegistry) {
       if (
         !filterAppType || filterAppType === APP_TYPE.KONNECTOR
       ) {
-        fetchingKonnectors = client.stackClient.fetchJSON('GET', '/konnectors/')
+        fetchingKonnectors = fetchUserApps(APP_TYPE.KONNECTOR)
       }
       if (
         !filterAppType || filterAppType === APP_TYPE.WEBAPP
       ) {
-        fetchingWebApps = client.stackClient.fetchJSON('GET', '/apps/')
+        fetchingWebApps = fetchUserApps(APP_TYPE.WEBAPP)
       }
       await fetchingRegistry
       dispatch({ type: FETCH_APPS })
       let installedApps = []
       if (fetchingWebApps) {
         let installedWebApps = await fetchingWebApps
-        installedWebApps = installedWebApps.map(w => {
-          // FIXME type konnector is missing from stack
-          w.attributes.type = APP_TYPE.WEBAPP
-          return w
-        })
         installedWebApps = installedWebApps.filter(
           app => !config.notDisplayedApps.includes(app.attributes.slug)
         )
@@ -414,11 +413,6 @@ export function fetchInstalledApps(client, lang, fetchingRegistry) {
       }
       if (fetchingKonnectors) {
         let installedKonnectors = await fetchingKonnectors
-        installedKonnectors = installedKonnectors.map(k => {
-          // FIXME type konnector is missing from stack
-          k.attributes.type = APP_TYPE.KONNECTOR
-          return k
-        })
         installedKonnectors = installedKonnectors.filter(
           app => !config.notDisplayedApps.includes(app.attributes.slug)
         )

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -151,7 +151,7 @@ export function _getRegistryAssetsLinks(client, manifest, appVersion) {
   }
 }
 
-export async function getFormattedInstalledApp(client, response) {
+export function getFormattedInstalledApp(client, response) {
   const appAttributes = _sanitizeManifest(response.attributes)
 
   const openingLink = response.links.related
@@ -211,11 +211,8 @@ function onAppUpdate(client, appResponse) {
         appResponse.type,
         appResponse.slug
       )
-      return getFormattedInstalledApp(client, appFromStack).then(
-        installedApp => {
-          return dispatch({ type: INSTALL_APP_SUCCESS, installedApp })
-        }
-      )
+      const installedApp = getFormattedInstalledApp(client, appFromStack)
+      return dispatch({ type: INSTALL_APP_SUCCESS, installedApp })
     }
   }
 }
@@ -406,11 +403,11 @@ export function fetchInstalledApps(client, lang, fetchingRegistry) {
       const promises = toFetch.map(type => fetchUserApps(client, type))
       await fetchingRegistry
       dispatch({ type: FETCH_APPS })
-      const installedApps = flatten(
-        await Promise.all(promises)
-      ).filter(x => shouldAppBeDisplayed(x.attributes))
-      const apps = await Promise.all(
-        installedApps.map(app => getFormattedInstalledApp(client, app))
+      const installedApps = flatten(await Promise.all(promises)).filter(x =>
+        shouldAppBeDisplayed(x.attributes)
+      )
+      const apps = installedApps.map(app =>
+        getFormattedInstalledApp(client, app)
       )
       dispatch({ type: FETCH_APPS_SUCCESS, apps, lang })
     } catch (e) {

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -1,5 +1,4 @@
 /* eslint-env browser */
-/* global cozy */
 
 import config from 'config/apps'
 import storeConfig from 'config'
@@ -509,7 +508,7 @@ export function installApp(client, app, source, isUpdate = false) {
       .join('&')
     if (terms) {
       try {
-        await termUtils.save(terms)
+        await termUtils.save(client, terms)
       } catch (e) {
         handleError(e)
       }

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -417,13 +417,13 @@ export function fetchInstalledApps(client, lang, fetchingRegistry) {
         !storeConfig.filterAppType ||
         storeConfig.filterAppType === APP_TYPE.KONNECTOR
       ) {
-        fetchingKonnectors = cozy.client.fetchJSON('GET', '/konnectors/')
+        fetchingKonnectors = client.stackClient.fetchJSON('GET', '/konnectors/')
       }
       if (
         !storeConfig.filterAppType ||
         storeConfig.filterAppType === APP_TYPE.WEBAPP
       ) {
-        fetchingWebApps = cozy.client.fetchJSON('GET', '/apps/')
+        fetchingWebApps = client.stackClient.fetchJSON('GET', '/apps/')
       }
       await fetchingRegistry
       dispatch({ type: FETCH_APPS })

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -469,7 +469,7 @@ function extractJsonApiError(e) {
   }
 }
 
-export function uninstallApp(app) {
+export function uninstallApp(client, app) {
   const { slug, type } = app
   return dispatch => {
     if (
@@ -483,9 +483,11 @@ export function uninstallApp(app) {
     // FIXME: hack to handle node type from stack for the konnectors
     const route =
       type === APP_TYPE.KONNECTOR || type === 'node' ? 'konnectors' : 'apps'
-    return cozy.client.fetchJSON('DELETE', `/${route}/${slug}`).catch(e => {
-      dispatch({ type: UNINSTALL_APP_FAILURE, error: extractJsonApiError(e) })
-    })
+    return client.stackClient
+      .fetchJSON('DELETE', `/${route}/${slug}`)
+      .catch(e => {
+        dispatch({ type: UNINSTALL_APP_FAILURE, error: extractJsonApiError(e) })
+      })
   }
 }
 

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -315,7 +315,7 @@ export function fetchLatestApp(
       })
     }
     try {
-      const formattedApp = await getFormattedRegistryApp(app, channel)
+      const formattedApp = await getFormattedRegistryApp(client, app, channel)
       formattedApp.installed = await _getInstalledInfos(app)
       // dispatch the app only if we are still in fetching status
       // (meant that the fetch has not been cancelled by a RESTORE_APP action)
@@ -346,12 +346,13 @@ export function fetchLatestApp(
 }
 
 export async function getFormattedRegistryApp(
+  client,
   responseApp,
   channel = DEFAULT_CHANNEL
 ) {
   let version = responseApp.latest_version
   if (!version) {
-    version = await cozy.client.fetchJSON(
+    version = await client.stackClient.fetchJSON(
       'GET',
       `/registry/${responseApp.slug}/${channel}/latest`
     )
@@ -472,7 +473,7 @@ export function fetchRegistryApps(client, lang, channel = DEFAULT_CHANNEL) {
     let filterParam = ''
     if (storeConfig.filterAppType)
       filterParam = `&filter[type]=${storeConfig.filterAppType}`
-    return cozy.client
+    return client.stackClient
       .fetchJSON(
         'GET',
         `/registry?limit=200&versionsChannel=${channel}&latestChannelVersion=${channel}${filterParam}`
@@ -485,7 +486,7 @@ export function fetchRegistryApps(client, lang, channel = DEFAULT_CHANNEL) {
           apps.map(app => {
             // no latest_version means no version for this channel
             if (!app.latest_version) return false // skip
-            return getFormattedRegistryApp(app).catch(err => {
+            return getFormattedRegistryApp(client, app).catch(err => {
               console.warn(
                 `Something went wrong when trying to fetch more informations about ${
                   app.slug

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -382,19 +382,18 @@ export async function getFormattedRegistryApp(
 
 export function fetchInstalledApps(client, lang, fetchingRegistry) {
   return async dispatch => {
+    const { filterAppType } = storeConfig
     try {
       // Start the HTTP requests as soon as possible
       let fetchingKonnectors = null
       let fetchingWebApps = null
       if (
-        !storeConfig.filterAppType ||
-        storeConfig.filterAppType === APP_TYPE.KONNECTOR
+        !filterAppType || filterAppType === APP_TYPE.KONNECTOR
       ) {
         fetchingKonnectors = client.stackClient.fetchJSON('GET', '/konnectors/')
       }
       if (
-        !storeConfig.filterAppType ||
-        storeConfig.filterAppType === APP_TYPE.WEBAPP
+        !filterAppType || filterAppType === APP_TYPE.WEBAPP
       ) {
         fetchingWebApps = client.stackClient.fetchJSON('GET', '/apps/')
       }

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -28,7 +28,7 @@ import {
   RESTORE_APP,
   SAVE_APP
 } from './reducers'
-import { fetchAppsFromChannel } from './client-helpers'
+import { fetchAppsFromChannel, fetchAppOrKonnector } from './client-helpers'
 
 const APP_STATE = {
   READY: 'ready',
@@ -207,13 +207,10 @@ function onAppUpdate(client, appResponse) {
     }
     if (appResponse.state === APP_STATE.READY) {
       // FIXME: hack to handle node type from stack for the konnectors
-      const route =
-        appResponse.type === APP_TYPE.KONNECTOR || appResponse.type === 'node'
-          ? 'konnectors'
-          : 'apps'
-      const appFromStack = await client.stackClient.fetchJSON(
-        'GET',
-        `/${route}/${appResponse.slug}`
+      const appFromStack = await fetchAppOrKonnector(
+        client,
+        appResponse.type,
+        appResponse.slug
       )
       return getFormattedInstalledApp(appFromStack).then(installedApp => {
         return dispatch({ type: INSTALL_APP_SUCCESS, installedApp })

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -180,11 +180,11 @@ export async function getFormattedInstalledApp(response) {
 }
 
 // only on the app initialisation
-export function initApp(lang) {
+export function initApp(client, lang) {
   return dispatch => {
     dispatch({ type: LOADING_APP })
-    dispatch(initializeRealtime())
-    return dispatch(fetchApps(lang))
+    dispatch(initializeRealtime(client))
+    return dispatch(fetchApps(client, lang))
   }
 }
 
@@ -407,7 +407,7 @@ export async function getFormattedRegistryApp(
   })
 }
 
-export function fetchInstalledApps(lang, fetchingRegistry) {
+export function fetchInstalledApps(client, lang, fetchingRegistry) {
   return async dispatch => {
     try {
       // Start the HTTP requests as soon as possible
@@ -466,7 +466,7 @@ export function fetchInstalledApps(lang, fetchingRegistry) {
   }
 }
 
-export function fetchRegistryApps(lang, channel = DEFAULT_CHANNEL) {
+export function fetchRegistryApps(client, lang, channel = DEFAULT_CHANNEL) {
   return dispatch => {
     dispatch({ type: FETCH_APPS })
     let filterParam = ''
@@ -509,10 +509,10 @@ export function fetchRegistryApps(lang, channel = DEFAULT_CHANNEL) {
   }
 }
 
-export function fetchApps(lang) {
+export function fetchApps(client, lang) {
   return async dispatch => {
-    const fetchingRegistry = dispatch(fetchRegistryApps(lang))
-    return dispatch(fetchInstalledApps(lang, fetchingRegistry))
+    const fetchingRegistry = dispatch(fetchRegistryApps(client, lang))
+    return dispatch(fetchInstalledApps(client, lang, fetchingRegistry))
   }
 }
 

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -541,7 +541,7 @@ async function _saveAppTerms(terms) {
   }
 }
 
-export function installApp(app, source, isUpdate = false) {
+export function installApp(client, app, source, isUpdate = false) {
   const { slug, type, terms } = app
   return async dispatch => {
     dispatch({ type: INSTALL_APP, slug })
@@ -565,7 +565,10 @@ export function installApp(app, source, isUpdate = false) {
     const verb = isUpdate ? 'PUT' : 'POST'
     const route = type === APP_TYPE.KONNECTOR ? 'konnectors' : 'apps'
     try {
-      await cozy.client.fetchJSON(verb, `/${route}/${slug}?${queryString}`)
+      await client.stackClient.fetchJSON(
+        verb,
+        `/${route}/${slug}?${queryString}`
+      )
     } catch (e) {
       handleError(e)
     }
@@ -573,12 +576,13 @@ export function installApp(app, source, isUpdate = false) {
 }
 
 export function installAppFromRegistry(
+  client,
   app,
   channel = DEFAULT_CHANNEL,
   isUpdate = false
 ) {
   return dispatch => {
     const source = `registry://${app.slug}/${channel}`
-    return dispatch(installApp(app, source, isUpdate))
+    return dispatch(installApp(client, app, source, isUpdate))
   }
 }

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -124,7 +124,7 @@ getContext.clearCache = () => {
   contextCache = null
 }
 
-export function _getRegistryAssetsLinks(manifest, appVersion) {
+export function _getRegistryAssetsLinks(client, manifest, appVersion) {
   if (!appVersion && manifest) appVersion = manifest.version
   if (!appVersion) return {}
   const screenshotsLinks =
@@ -132,7 +132,7 @@ export function _getRegistryAssetsLinks(manifest, appVersion) {
     manifest.screenshots.map(name => {
       let fileName = name
       if (fileName[0] === '/') fileName = fileName.slice(1)
-      return `${cozy.client._url}/registry/${
+      return `${client.stackClient.uri}/registry/${
         manifest.slug
       }/${appVersion}/screenshots/${fileName}`
     })
@@ -142,7 +142,7 @@ export function _getRegistryAssetsLinks(manifest, appVersion) {
     manifest.slug &&
     manifest.partnership &&
     manifest.partnership.icon &&
-    `${cozy.client._url}/registry/${
+    `${client.stackClient.uri}/registry/${
       manifest.slug
     }/${appVersion}/partnership_icon`
   return {
@@ -157,6 +157,7 @@ export async function getFormattedInstalledApp(client, response) {
 
   const openingLink = response.links.related
   const { screenshotsLinks, partnershipIconLink } = _getRegistryAssetsLinks(
+    client,
     appAttributes,
     appAttributes.version
   )
@@ -367,7 +368,7 @@ export async function getFormattedRegistryApp(
     screenshotsLinks,
     iconLink,
     partnershipIconLink
-  } = _getRegistryAssetsLinks(manifest, versionFromRegistry)
+  } = _getRegistryAssetsLinks(client, manifest, versionFromRegistry)
   const partnership =
     !!manifest.partnership &&
     Object.assign({}, manifest.partnership, {

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -146,7 +146,7 @@ export function _getRegistryAssetsLinks(manifest, appVersion) {
   }
 }
 
-export async function getFormattedInstalledApp(response) {
+export async function getFormattedInstalledApp(client, response) {
   const appAttributes = _sanitizeManifest(response.attributes)
 
   const openingLink = response.links.related
@@ -205,9 +205,11 @@ function onAppUpdate(client, appResponse) {
         appResponse.type,
         appResponse.slug
       )
-      return getFormattedInstalledApp(appFromStack).then(installedApp => {
-        return dispatch({ type: INSTALL_APP_SUCCESS, installedApp })
-      })
+      return getFormattedInstalledApp(client, appFromStack).then(
+        installedApp => {
+          return dispatch({ type: INSTALL_APP_SUCCESS, installedApp })
+        }
+      )
     }
   }
 }
@@ -401,7 +403,9 @@ export function fetchInstalledApps(client, lang, fetchingRegistry) {
 
         await Promise.all(promises)
       ).filter(shouldAppBeDisplayed)
-      const apps = await Promise.all(installedApps.map(getFormattedInstalledApp))
+      const apps = await Promise.all(
+        installedApps.map(app => getFormattedInstalledApp(client, app))
+      )
       dispatch({ type: FETCH_APPS_SUCCESS, apps, lang })
     } catch (e) {
       dispatch({ type: FETCH_APPS_FAILURE, error: e })

--- a/src/ducks/apps/terms.js
+++ b/src/ducks/apps/terms.js
@@ -1,4 +1,4 @@
-const TERMS_DOCTYPE = 'io.cozy.terms'
+import { TERMS_DOCTYPE } from 'lib/schema'
 
 async function save(client, terms) {
   const { id, ...termsAttributes } = terms

--- a/src/ducks/apps/terms.js
+++ b/src/ducks/apps/terms.js
@@ -1,0 +1,56 @@
+/* global cozy */
+const TERMS_DOCTYPE = 'io.cozy.terms'
+
+let termsIndexCache = null
+async function _getOrCreateTermsIndex() {
+  termsIndexCache = await cozy.client.data.defineIndex(TERMS_DOCTYPE, [
+    'termsId',
+    'version'
+  ])
+  return termsIndexCache
+}
+
+async function save(terms) {
+  const { id, ...termsAttributes } = terms
+  // We use : as separator for <id>:<version>
+  let savedTermsDocs = null
+  try {
+    savedTermsDocs = await cozy.client.data.query(
+      await _getOrCreateTermsIndex(),
+      {
+        selector: {
+          termsId: id,
+          version: termsAttributes.version
+        },
+        limit: 1
+      }
+    )
+  } catch (e) {
+    throw e
+  }
+  if (savedTermsDocs && savedTermsDocs.length) {
+    // we just update the url if this is the same id and same version
+    // but the url changed
+    const savedTerms = savedTermsDocs[0]
+    if (
+      savedTerms.termsId == id &&
+      savedTerms.version == termsAttributes.version &&
+      savedTerms.url != termsAttributes.url
+    ) {
+      await cozy.client.data.updateAttributes(TERMS_DOCTYPE, savedTerms._id, {
+        url: termsAttributes.url
+      })
+    }
+  } else {
+    const termsToSave = Object.assign({}, termsAttributes, {
+      termsId: id,
+      accepted: true,
+      acceptedAt: new Date()
+    })
+    await cozy.client.data.create(TERMS_DOCTYPE, termsToSave)
+  }
+}
+
+export default {
+  save
+}

--- a/src/ducks/apps/terms.js
+++ b/src/ducks/apps/terms.js
@@ -28,8 +28,9 @@ async function save(client, terms) {
       await client.save(termsToSave)
     }
   } else {
-    const termsToSave = Object.assign({}, termsAttributes, {
+    const termsToSave = {
       _type: TERMS_DOCTYPE,
+      ...termsAttributes,
       termsId: id,
       accepted: true,
       acceptedAt: new Date()

--- a/src/ducks/components/App.jsx
+++ b/src/ducks/components/App.jsx
@@ -15,6 +15,7 @@ import { Discover, MyApplications } from 'ducks/apps/Containers'
 import { Layout, Main } from 'cozy-ui/react/Layout'
 import Alerter from 'cozy-ui/react/Alerter'
 import { IconSprite } from 'cozy-ui/react'
+import compose from 'lodash/flowRight'
 
 import { enabledPages } from 'config'
 
@@ -74,13 +75,12 @@ export const mapDispatchToProps = (dispatch, ownProps) => ({
   restoreAppIfSaved: () => dispatch(restoreAppIfSaved())
 })
 
-export default hot(module)(
-  withRouter(
-    translate()(
-      connect(
-        mapStateToProps,
-        mapDispatchToProps
-      )(App)
-    )
+export default compose(
+  hot(module),
+  withRouter,
+  translate(),
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
   )
-)
+)(App)

--- a/src/ducks/components/App.jsx
+++ b/src/ducks/components/App.jsx
@@ -16,6 +16,7 @@ import { Layout, Main } from 'cozy-ui/react/Layout'
 import Alerter from 'cozy-ui/react/Alerter'
 import { IconSprite } from 'cozy-ui/react'
 import compose from 'lodash/flowRight'
+import { withClient } from 'cozy-client'
 
 import { enabledPages } from 'config'
 
@@ -71,7 +72,7 @@ export const mapStateToProps = state => ({
 })
 
 export const mapDispatchToProps = (dispatch, ownProps) => ({
-  initApp: () => dispatch(initApp(ownProps.lang)),
+  initApp: () => dispatch(initApp(ownProps.client, ownProps.lang)),
   restoreAppIfSaved: () => dispatch(restoreAppIfSaved())
 })
 
@@ -79,6 +80,7 @@ export default compose(
   hot(module),
   withRouter,
   translate(),
+  withClient,
   connect(
     mapStateToProps,
     mapDispatchToProps

--- a/src/ducks/components/intents/InstallAppIntent.jsx
+++ b/src/ducks/components/intents/InstallAppIntent.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import compose from 'lodash/flowRight'
+import { withClient } from 'cozy-client'
 
 import { translate } from 'cozy-ui/react/I18n'
 
@@ -153,15 +154,15 @@ const mapStateToProps = (state, ownProps) => ({
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
   initAppIntent: () => {
-    dispatch(initAppIntent(ownProps.lang, ownProps.data.slug))
+    dispatch(initAppIntent(ownProps.client, ownProps.lang, ownProps.data.slug))
   },
   installApp: (app, channel) => dispatch(installAppFromRegistry(app, channel))
 })
 
 // translate last to pass the lang property to fetchApps()
 export default compose(
-  translate(),
   withClient,
+  translate(),
   connect(
     mapStateToProps,
     mapDispatchToProps

--- a/src/ducks/components/intents/InstallAppIntent.jsx
+++ b/src/ducks/components/intents/InstallAppIntent.jsx
@@ -1,5 +1,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
+import compose from 'lodash/flowRight'
+
 import { translate } from 'cozy-ui/react/I18n'
 
 import AppInstallation from 'ducks/apps/components/AppInstallation'
@@ -157,9 +159,10 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
 })
 
 // translate last to pass the lang property to fetchApps()
-export default translate()(
+export default compose(
+  translate(),
   connect(
     mapStateToProps,
     mapDispatchToProps
-  )(InstallAppIntent)
-)
+  )
+)(InstallAppIntent)

--- a/src/ducks/components/intents/InstallAppIntent.jsx
+++ b/src/ducks/components/intents/InstallAppIntent.jsx
@@ -161,6 +161,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
 // translate last to pass the lang property to fetchApps()
 export default compose(
   translate(),
+  withClient,
   connect(
     mapStateToProps,
     mapDispatchToProps

--- a/src/ducks/components/intents/IntentHandler.jsx
+++ b/src/ducks/components/intents/IntentHandler.jsx
@@ -1,6 +1,7 @@
 import React, { Children, Component } from 'react'
 import { translate } from 'cozy-ui/react/I18n'
-
+import { withClient } from 'cozy-client'
+import Intents from 'cozy-interapp'
 import Spinner from 'cozy-ui/react/Spinner'
 
 const CREATING = 'creating'
@@ -17,14 +18,10 @@ class IntentHandler extends Component {
       status: CREATING
     }
 
-    props.intents
+    const client = this.props.client
+    const intents = new Intents({ client })
+    intents
       .createService()
-      // Free : easy mocking !
-      // Promise.resolve({
-      //   getData: () => ({ slug: <konnector slug> }),
-      //   getIntent: () => ({ action: 'INSTALL', type: 'io.cozy.apps' }),
-      //   terminate: (doc) => { alert(`Installed ${doc.name}`) }
-      // })
       .then(service =>
         this.setState({
           status: CREATED,
@@ -78,4 +75,4 @@ class IntentHandler extends Component {
   }
 }
 
-export default translate()(IntentHandler)
+export default withClient(translate()(IntentHandler))

--- a/src/lib/schema.js
+++ b/src/lib/schema.js
@@ -1,0 +1,7 @@
+export const TERMS_DOCTYPE = 'io.cozy.terms'
+
+export default {
+  terms: {
+    doctype: 'io.cozy.terms'
+  }
+}

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -19,10 +19,7 @@ const renderApp = function({ client, lang }) {
 document.addEventListener('DOMContentLoaded', () => {
   const root = document.querySelector('[role=application]')
   const data = root.dataset
-  cozy.client.init({
-    cozyURL: '//' + data.cozyDomain,
-    token: data.cozyToken
-  })
+  
   const protocol = window.location.protocol
   const client = new CozyClient({
     uri: `${protocol}//${data.cozyDomain}`,

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -7,6 +7,7 @@ import { render } from 'react-dom'
 import CozyClient from 'cozy-client'
 
 import store from 'lib/store'
+import schema from 'lib/schema'
 
 const renderApp = function({ client, lang }) {
   const Root = require('ducks/components/Root').default
@@ -22,7 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const protocol = window.location.protocol
   const client = new CozyClient({
     uri: `${protocol}//${data.cozyDomain}`,
-    schema: {},
+    schema,
     token: data.cozyToken
   })
   cozy.bar.init({

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -19,7 +19,6 @@ const renderApp = function({ client, lang }) {
 document.addEventListener('DOMContentLoaded', () => {
   const root = document.querySelector('[role=application]')
   const data = root.dataset
-
   const protocol = window.location.protocol
   const client = new CozyClient({
     uri: `${protocol}//${data.cozyDomain}`,

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -19,7 +19,7 @@ const renderApp = function({ client, lang }) {
 document.addEventListener('DOMContentLoaded', () => {
   const root = document.querySelector('[role=application]')
   const data = root.dataset
-  
+
   const protocol = window.location.protocol
   const client = new CozyClient({
     uri: `${protocol}//${data.cozyDomain}`,

--- a/src/targets/intents/index.jsx
+++ b/src/targets/intents/index.jsx
@@ -1,4 +1,3 @@
-/* global cozy */
 import 'styles'
 
 import { Provider } from 'react-redux'
@@ -6,21 +5,19 @@ import React from 'react'
 import { render } from 'react-dom'
 import store from 'lib/store'
 
+import CozyClient, { CozyProvider } from 'cozy-client'
 import I18n from 'cozy-ui/react/I18n'
 import IntentHandler from '../../ducks/components/intents/IntentHandler'
 import InstallAppIntent from '../../ducks/components/intents/InstallAppIntent'
-
-// import 'styles/intents.styl'
-
-// const lang = document.documentElement.getAttribute('lang') || 'en'
-// const context = window.context || 'cozy'
 
 document.addEventListener('DOMContentLoaded', () => {
   const root = document.querySelector('[role=application]')
   const appData = root.dataset
 
-  cozy.client.init({
-    cozyURL: '//' + appData.cozyDomain,
+  const protocol = window.location.protocol
+  const client = new CozyClient({
+    uri: `${protocol}//${appData.cozyDomain}`,
+    schema: {},
     token: appData.cozyToken
   })
 
@@ -29,11 +26,13 @@ document.addEventListener('DOMContentLoaded', () => {
       lang={appData.cozyLocale}
       dictRequire={lang => require(`../../locales/${lang}`)}
     >
-      <Provider store={store}>
-        <IntentHandler appData={appData} intents={cozy.client.intents}>
-          <InstallAppIntent action="INSTALL" type="io.cozy.apps" />
-        </IntentHandler>
-      </Provider>
+      <CozyProvider store={store} client={client}>
+        <Provider store={store}>
+          <IntentHandler appData={appData}>
+            <InstallAppIntent action="INSTALL" type="io.cozy.apps" />
+          </IntentHandler>
+        </Provider>
+      </CozyProvider>
     </I18n>,
     document.querySelector('[role=application]')
   )

--- a/src/targets/intents/index.jsx
+++ b/src/targets/intents/index.jsx
@@ -9,6 +9,7 @@ import CozyClient, { CozyProvider } from 'cozy-client'
 import I18n from 'cozy-ui/react/I18n'
 import IntentHandler from '../../ducks/components/intents/IntentHandler'
 import InstallAppIntent from '../../ducks/components/intents/InstallAppIntent'
+import schema from 'lib/schema'
 
 document.addEventListener('DOMContentLoaded', () => {
   const root = document.querySelector('[role=application]')
@@ -17,7 +18,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const protocol = window.location.protocol
   const client = new CozyClient({
     uri: `${protocol}//${appData.cozyDomain}`,
-    schema: {},
+    schema,
     token: appData.cozyToken
   })
 

--- a/test/components/intents/__snapshots__/installAppIntent.spec.js.snap
+++ b/test/components/intents/__snapshots__/installAppIntent.spec.js.snap
@@ -12,7 +12,7 @@ exports[`InstallAppIntent component should be rendered correctly 1`] = `
   <div
     className="coz-intent-content"
   >
-    <Connect(Wrapper)
+    <Wrapped
       appSlug="drive"
       installApp={[Function]}
     />

--- a/test/components/intents/installAppIntent.spec.js
+++ b/test/components/intents/installAppIntent.spec.js
@@ -5,7 +5,11 @@ import { mount, shallow } from 'enzyme'
 
 import { InstallAppIntent } from 'ducks/components/intents/InstallAppIntent'
 import AppInstallation from 'ducks/apps/components/AppInstallation'
+import CozyClient, { CozyProvider } from 'cozy-client'
+
 jest.mock('ducks/apps/components/AppInstallation')
+
+AppInstallation.mockImplementation(() => null)
 
 describe('InstallAppIntent component', () => {
   const props = {
@@ -24,19 +28,26 @@ describe('InstallAppIntent component', () => {
     jest.clearAllMocks()
   })
 
+  const client = new CozyClient({})
+
   it('should be rendered correctly', () => {
-    const componentWrapper = shallow(<InstallAppIntent {...props} />)
+    const componentWrapper = shallow(
+      <CozyProvider client={client}>
+        <InstallAppIntent {...props} />
+      </CozyProvider>
+    ).dive()
     const component = componentWrapper.getElement()
 
     expect(component).toMatchSnapshot()
   })
 
-  it('calls AppInstallation correctly', () => {
-    mount(<InstallAppIntent {...props} />)
+  it('should render AppInstallation correctly', () => {
+    const root = mount(
+      <CozyProvider client={client}>
+        <InstallAppIntent {...props} />
+      </CozyProvider>
+    )
 
-    expect(AppInstallation).toHaveBeenCalledTimes(1)
-
-    const call = AppInstallation.mock.calls[0][0]
-    expect(call.appSlug).toBeDefined()
+    expect(root.find(AppInstallation).length).toBe(1)
   })
 })

--- a/test/ducks/apps/__snapshots__/index.spec.js.snap
+++ b/test/ducks/apps/__snapshots__/index.spec.js.snap
@@ -301,7 +301,7 @@ Object {
 exports[`Apps duck helpers _getRegistryAssetsLinks should handle partnership icon link 1`] = `
 Object {
   "iconLink": "/registry/mock/1.0.0/icon",
-  "partnershipIconLink": "//cozy.tools/registry/mock/1.0.0/partnership_icon",
+  "partnershipIconLink": "https://testcozy.mycozy.cloud/registry/mock/1.0.0/partnership_icon",
   "screenshotsLinks": undefined,
 }
 `;
@@ -311,9 +311,9 @@ Object {
   "iconLink": "/registry/mock/1.0.0/icon",
   "partnershipIconLink": undefined,
   "screenshotsLinks": Array [
-    "//cozy.tools/registry/mock/1.0.0/screenshots/screen1.jpg",
-    "//cozy.tools/registry/mock/1.0.0/screenshots/screen2.png",
-    "//cozy.tools/registry/mock/1.0.0/screenshots/screen3.gif",
+    "https://testcozy.mycozy.cloud/registry/mock/1.0.0/screenshots/screen1.jpg",
+    "https://testcozy.mycozy.cloud/registry/mock/1.0.0/screenshots/screen2.png",
+    "https://testcozy.mycozy.cloud/registry/mock/1.0.0/screenshots/screen3.gif",
   ],
 }
 `;

--- a/test/ducks/apps/components/__snapshots__/channelModal.spec.js.snap
+++ b/test/ducks/apps/components/__snapshots__/channelModal.spec.js.snap
@@ -25,7 +25,7 @@ exports[`ChannelModal component should be rendered correctly if app found and fr
       secondaryType="secondary"
       size="small"
     >
-      <Connect(Wrapper)
+      <Wrapped
         appSlug="photos"
         channel="beta"
         onCancel={[Function]}
@@ -61,7 +61,7 @@ exports[`ChannelModal component should not break the permissions part if no perm
       secondaryType="secondary"
       size="small"
     >
-      <Connect(Wrapper)
+      <Wrapped
         appSlug="photos"
         channel="beta"
         onCancel={[Function]}

--- a/test/ducks/apps/components/__snapshots__/configureModal.spec.js.snap
+++ b/test/ducks/apps/components/__snapshots__/configureModal.spec.js.snap
@@ -4,6 +4,7 @@ exports[`ConfigureModal component renders 1`] = `
 <IntentModal
   action="CREATE"
   closable={true}
+  create={[Function]}
   dismissAction={[MockFunction]}
   doctype="io.cozy.accounts"
   height="41rem"

--- a/test/ducks/apps/components/__snapshots__/installModal.spec.js.snap
+++ b/test/ducks/apps/components/__snapshots__/installModal.spec.js.snap
@@ -25,7 +25,7 @@ exports[`InstallModal component should be rendered correctly if app found 1`] = 
       secondaryType="secondary"
       size="small"
     >
-      <Connect(Wrapper)
+      <Wrapped
         appSlug="photos"
         onCancel={[Function]}
       />
@@ -59,7 +59,7 @@ exports[`InstallModal component should be rendered correctly to update app with 
       secondaryType="secondary"
       size="small"
     >
-      <Connect(Wrapper)
+      <Wrapped
         appSlug="photos"
         onCancel={[Function]}
       />
@@ -93,7 +93,7 @@ exports[`InstallModal component should be rendered correctly with also app in re
       secondaryType="secondary"
       size="small"
     >
-      <Connect(Wrapper)
+      <Wrapped
         appSlug="photos"
         onCancel={[Function]}
       />
@@ -127,7 +127,7 @@ exports[`InstallModal component should not break the permissions part if no perm
       secondaryType="secondary"
       size="small"
     >
-      <Connect(Wrapper)
+      <Wrapped
         appSlug="photos"
         onCancel={[Function]}
       />

--- a/test/ducks/apps/components/applicationPage/__snapshots__/index.spec.js.snap
+++ b/test/ducks/apps/components/applicationPage/__snapshots__/index.spec.js.snap
@@ -147,7 +147,7 @@ Gestionnaire de photos pour Cozy v3 :tada:",
         namePrefix="Cozy"
         parent="/myapps"
       />
-      <withRouter(Wrapper)
+      <Wrapped
         app={
           Object {
             "categories": Array [
@@ -443,7 +443,7 @@ Gestionnaire de photos pour Cozy v3 :tada:",
         }
         slug="photos"
       />
-      <withRouter(Wrapper)
+      <Wrapped
         app={
           Object {
             "categories": Array [
@@ -716,7 +716,7 @@ exports[`ApplicationPage component should be rendered correctly with konnector i
         namePrefix=""
         parent="/myapps"
       />
-      <withRouter(Wrapper)
+      <Wrapped
         app={
           Object {
             "categories": Array [
@@ -971,7 +971,7 @@ Gestionnaire de photos pour Cozy v3 :tada:",
         namePrefix="Cozy"
         parent="/myapps"
       />
-      <withRouter(Wrapper)
+      <Wrapped
         app={
           Object {
             "categories": Array [
@@ -1242,7 +1242,7 @@ exports[`ApplicationPage component should be rendered correctly with provided in
         namePrefix=""
         parent="/myapps"
       />
-      <withRouter(Wrapper)
+      <Wrapped
         app={
           Object {
             "categories": Array [
@@ -1481,7 +1481,7 @@ exports[`ApplicationPage component should be rendered correctly without app desc
         namePrefix=""
         parent="/myapps"
       />
-      <withRouter(Wrapper)
+      <Wrapped
         app={
           Object {
             "categories": Array [
@@ -1867,7 +1867,7 @@ Gestionnaire de photos pour Cozy v3 :tada:",
         namePrefix="Cozy"
         parent="/myapps"
       />
-      <withRouter(Wrapper)
+      <Wrapped
         app={
           Object {
             "categories": Array [
@@ -2277,7 +2277,7 @@ Gestionnaire de photos pour Cozy v3 :tada:",
         namePrefix="Cozy"
         parent="/myapps"
       />
-      <withRouter(Wrapper)
+      <Wrapped
         app={
           Object {
             "categories": Array [

--- a/test/ducks/apps/components/applicationRouting/__snapshots__/channelRoute.spec.js.snap
+++ b/test/ducks/apps/components/applicationRouting/__snapshots__/channelRoute.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ChannelRoute component should display install modal if app found and in the registry and installed 1`] = `
-<Wrapper
+<Wrapped
   appSlug="collect"
   channel="beta"
   dismissAction={[Function]}
@@ -12,7 +12,7 @@ exports[`ChannelRoute component should display install modal if app found and in
 `;
 
 exports[`ChannelRoute component should display install modal if app found and in the registry even if not installed 1`] = `
-<Wrapper
+<Wrapped
   appSlug="photos"
   channel="beta"
   dismissAction={[Function]}

--- a/test/ducks/apps/components/applicationRouting/__snapshots__/installRoute.spec.js.snap
+++ b/test/ducks/apps/components/applicationRouting/__snapshots__/installRoute.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InstallRoute component should display install modal if app found in the registry but not installed 1`] = `
-<Wrapper
+<Wrapped
   app={
     Object {
       "categories": Array [
@@ -44,7 +44,7 @@ exports[`InstallRoute component should display install modal if app found in the
 `;
 
 exports[`InstallRoute component should display install modal if app found in the registry installed but with available version 1`] = `
-<Wrapper
+<Wrapped
   app={
     Object {
       "availableVersion": "3.0.0",

--- a/test/ducks/apps/components/applicationRouting/__snapshots__/uninstallRoute.spec.js.snap
+++ b/test/ducks/apps/components/applicationRouting/__snapshots__/uninstallRoute.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`UninstallRoute component should display uninstall modal if installed app found 1`] = `
-<Connect(Wrapper)
+<Wrapped
   appSlug="tasky"
   dismissAction={[Function]}
   onNotInstalled={[Function]}

--- a/test/ducks/apps/components/configureModal.spec.js
+++ b/test/ducks/apps/components/configureModal.spec.js
@@ -6,6 +6,7 @@ import React from 'react'
 import { shallow } from 'enzyme'
 
 import { ConfigureModal } from 'ducks/apps/components/ConfigureModal'
+import CozyClient from 'cozy-client'
 
 describe('ConfigureModal component', () => {
   const konnector = {
@@ -22,22 +23,34 @@ describe('ConfigureModal component', () => {
     onWebApp: jest.fn()
   }
 
+  let component
+
+  const setup = props => {
+    const client = new CozyClient({
+      stackClient: { uri: 'https://cozy.tools' }
+    })
+
+    component = shallow(
+      <ConfigureModal {...props} client={client} />
+    ).getElement()
+  }
+
   it('renders', () => {
-    const component = shallow(<ConfigureModal {...props} />).getElement()
+    setup(props)
     expect(component).toMatchSnapshot()
   })
 
   it('calls onNotInstalled', () => {
     const uninstalledKonnector = { ...konnector, installed: false }
     const uninstalledProps = { ...props, app: uninstalledKonnector }
-    shallow(<ConfigureModal {...uninstalledProps} />)
+    setup(uninstalledProps)
     expect(uninstalledProps.onNotInstalled.mock.calls.length).toBe(1)
   })
 
   it('calls onWebApp', () => {
     const webApp = { installed: true, slug: 'photos', type: 'webapp' }
     const appProps = { ...props, app: webApp }
-    shallow(<ConfigureModal {...appProps} />)
+    setup(appProps)
     expect(appProps.onWebApp.mock.calls.length).toBe(1)
   })
 })

--- a/test/ducks/apps/components/uninstallModal.spec.js
+++ b/test/ducks/apps/components/uninstallModal.spec.js
@@ -42,18 +42,23 @@ const getMockProps = (slug, uninstallError = null) => ({
 })
 
 describe('UninstallModal component', () => {
+  let mockClient
   beforeAll(() => {
     // define global mock url
-    global.cozy = {
-      client: {
-        _url: '//cozytest.mock.cc'
+    mockClient = {
+      stackClient: {
+        uri: '//cozytest.mock.cc'
       }
     }
   })
 
   it('should be rendered correctly (app uninstallable)', () => {
     const component = shallow(
-      <UninstallModal t={tMock} {...getMockProps('photos')} />
+      <UninstallModal
+        client={mockClient}
+        t={tMock}
+        {...getMockProps('photos')}
+      />
     ).getElement()
     expect(component).toMatchSnapshot()
   })
@@ -61,13 +66,15 @@ describe('UninstallModal component', () => {
   it('calls onNotInstalled', () => {
     const props = getMockProps('photos')
     props.installed = false
-    shallow(<UninstallModal t={tMock} {...props} />)
+    shallow(<UninstallModal client={mockClient} t={tMock} {...props} />)
     expect(props.onNotInstalled.mock.calls.length).toBe(1)
   })
 
   it('should handle correctly error from props', () => {
     const mockProps = getMockProps('photos', mockError)
-    const component = shallow(<UninstallModal t={tMock} {...mockProps} />)
+    const component = shallow(
+      <UninstallModal client={mockClient} t={tMock} {...mockProps} />
+    )
     expect(component.getElement()).toMatchSnapshot()
   })
 
@@ -76,7 +83,9 @@ describe('UninstallModal component', () => {
       'photos',
       new Error('A linked OAuth client exists for this app')
     )
-    const component = shallow(<UninstallModal t={tMock} {...mockProps} />)
+    const component = shallow(
+      <UninstallModal client={mockClient} t={tMock} {...mockProps} />
+    )
     expect(component.getElement()).toMatchSnapshot()
   })
 })

--- a/test/ducks/apps/index.spec.js
+++ b/test/ducks/apps/index.spec.js
@@ -152,7 +152,6 @@ describe('Apps duck actions', () => {
 })
 
 describe('Apps duck helpers', () => {
-
   let cozyClient
   beforeEach(() => {
     cozyClient = new CozyClient({
@@ -307,18 +306,19 @@ describe('Apps duck helpers', () => {
 
   describe('_getRegistryAssetsLinks', () => {
     it('should handle empty manifest or appVersion', () => {
-      expect(_getRegistryAssetsLinks({})).toStrictEqual({})
-      expect(_getRegistryAssetsLinks()).toStrictEqual({})
-      expect(_getRegistryAssetsLinks({}, '1.0.0')).toMatchSnapshot()
+      expect(_getRegistryAssetsLinks(cozyClient, {})).toStrictEqual({})
+      expect(_getRegistryAssetsLinks(cozyClient)).toStrictEqual({})
+      expect(_getRegistryAssetsLinks(cozyClient, {}, '1.0.0')).toMatchSnapshot()
     })
     it('should handle icon link from manifest slug and version', () => {
       expect(
-        _getRegistryAssetsLinks({ slug: 'mock' }, '1.0.0')
+        _getRegistryAssetsLinks(cozyClient, { slug: 'mock' }, '1.0.0')
       ).toMatchSnapshot()
     })
     it('should handle screenshots links', () => {
       expect(
         _getRegistryAssetsLinks(
+          cozyClient,
           {
             slug: 'mock',
             screenshots: ['screen1.jpg', 'screen2.png', '/screen3.gif']
@@ -330,6 +330,7 @@ describe('Apps duck helpers', () => {
     it('should handle partnership icon link', () => {
       expect(
         _getRegistryAssetsLinks(
+          cozyClient,
           {
             slug: 'mock',
             partnership: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1480,11 +1480,6 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-argsarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/argsarray/-/argsarray-0.0.1.tgz#6e7207b4ecdb39b0af88303fa5ae22bda8df61cb"
-  integrity sha1-bnIHtOzbObCviDA/pa4ivajfYcs=
-
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -2681,11 +2676,6 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer-from@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.0.tgz#87fcaa3a298358e0ade6e442cfce840740d1ad04"
-  integrity sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==
-
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -3045,11 +3035,6 @@ cliui@^4.0.0:
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
-clone-buffer@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
-  integrity sha1-4+JbIHrE5wGvch4staFnksrD3Fg=
-
 clone@2.x, clone@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
@@ -3339,16 +3324,6 @@ cozy-bar@6.1.2:
     redux "^3.7.2"
     redux-persist "^5.4.0"
     redux-thunk "^2.2.0"
-
-cozy-client-js@0.15.1:
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.15.1.tgz#187e83021a730291f6fdc6ac287c712f9bb56e3f"
-  integrity sha512-8qa6WeKkuYKQ04gaR8R4HJ/dKeeMNO389QrhJlh4TJnRDkqA4qM7vlCNwIjNQ9bRsy86CqtD/IAvU62QglF03Q==
-  dependencies:
-    core-js "^2.5.3"
-    isomorphic-fetch "^2.2.1"
-    pouchdb-browser "7.0.0"
-    pouchdb-find "7.0.0"
 
 cozy-client-js@^0.3.19:
   version "0.3.21"
@@ -4345,11 +4320,6 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es6-denodeify@^0.1.1:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/es6-denodeify/-/es6-denodeify-0.1.5.tgz#31d4d5fe9c5503e125460439310e16a2a3f39c1f"
-  integrity sha1-MdTV/pxVA+ElRgQ5MQ4WoqPznB8=
-
 es6-promise@^4.0.3:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
@@ -5083,14 +5053,6 @@ fbjs@^0.8.16:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
-
-fetch-cookie@0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/fetch-cookie/-/fetch-cookie-0.7.0.tgz#a6fc137ad8363aa89125864c6451b86ecb7de802"
-  integrity sha512-Mm5pGlT3agW6t71xVM7vMZPIvI7T4FaTuFW4jari6dVzYHFDb3WZZsGpN22r/o3XMdkM0E7sPd1EGeyVbH2Tgg==
-  dependencies:
-    es6-denodeify "^0.1.1"
-    tough-cookie "^2.3.1"
 
 figgy-pudding@^3.1.0, figgy-pudding@^3.5.1:
   version "3.5.1"
@@ -6053,7 +6015,7 @@ image-size@^0.5.1:
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
   integrity sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=
 
-immediate@3.0.6, immediate@~3.0.5:
+immediate@~3.0.5:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
   integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
@@ -6598,7 +6560,7 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
+isomorphic-fetch@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
   integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
@@ -8066,11 +8028,6 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-fetch@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
-  integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
-
 node-forge@0.7.5:
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.5.tgz#6c152c345ce11c52f465c2abd957e8639cd674df"
@@ -9042,117 +8999,6 @@ posthtml@^0.9.2:
     posthtml-parser "^0.2.0"
     posthtml-render "^1.0.5"
 
-pouchdb-abstract-mapreduce@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pouchdb-abstract-mapreduce/-/pouchdb-abstract-mapreduce-7.0.0.tgz#946d79073c9795ca03c9b5c318a64372422e8740"
-  integrity sha512-C1sb9AIJYTFOUPtuPaAYBCfd09DK82LmeYEtM4h1Z+wG76zj9U1NEg8T+CwxcpOF7eX3ZN5EmSfa3k/ZlyMUgQ==
-  dependencies:
-    pouchdb-binary-utils "7.0.0"
-    pouchdb-collate "7.0.0"
-    pouchdb-collections "7.0.0"
-    pouchdb-errors "7.0.0"
-    pouchdb-fetch "7.0.0"
-    pouchdb-mapreduce-utils "7.0.0"
-    pouchdb-md5 "7.0.0"
-    pouchdb-utils "7.0.0"
-
-pouchdb-binary-utils@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pouchdb-binary-utils/-/pouchdb-binary-utils-7.0.0.tgz#cb71a288b09572a231f6bab1b4aed201c4d219a7"
-  integrity sha512-yUktdOPIPvOVouCjJN3uop+bCcpdPwePrLm9eUAZNgEYnUFu0njdx7Q0WRsZ7UJ6l75HinL5ZHk4bnvEt86FLw==
-  dependencies:
-    buffer-from "1.1.0"
-
-pouchdb-browser@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pouchdb-browser/-/pouchdb-browser-7.0.0.tgz#d493fd738f21f7c91f17bbb7ee7ad97c2072e546"
-  integrity sha512-a0AikmIM8BJ4ROWnfRtmQWW3JlFdHvfcQQWxY2V1CesLJYqPkTzwSUDD3QsiU+edpTSK8fIrEq257W15qZzXYQ==
-  dependencies:
-    argsarray "0.0.1"
-    immediate "3.0.6"
-    inherits "2.0.3"
-    spark-md5 "3.0.0"
-    uuid "3.2.1"
-    vuvuzela "1.0.3"
-
-pouchdb-collate@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pouchdb-collate/-/pouchdb-collate-7.0.0.tgz#4f9a0a03c236f1677a971c400b79b7baf6379a4d"
-  integrity sha512-0O67rnNGVD9OUbDx+6DLPcE3zz7w6gieNCvrbvaI5ibIXuLpyMyLjD6OdRe/19LbstEfZaOp+SYUhQs+TP8Plg==
-
-pouchdb-collections@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pouchdb-collections/-/pouchdb-collections-7.0.0.tgz#fd1f632337dc6301b0ff8649732ca79204e41780"
-  integrity sha512-DaoUr/vU24Q3gM6ghj0va9j/oBanPwkbhkvnqSyC3Dm5dgf5pculNxueLF9PKMo3ycApoWzHMh6N2N8KJbDU2Q==
-
-pouchdb-errors@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pouchdb-errors/-/pouchdb-errors-7.0.0.tgz#4e2a5a8b82af20cbe5f9970ca90b7ec74563caa0"
-  integrity sha512-dTusY8nnTw4HIztCrNl7AoGgwvS1bVf/3/97hDaGc4ytn72V9/4dK8kTqlimi3UpaurohYRnqac0SGXYP8vgXA==
-  dependencies:
-    inherits "2.0.3"
-
-pouchdb-fetch@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pouchdb-fetch/-/pouchdb-fetch-7.0.0.tgz#6b56cc49863837f8d5e38b0956ace03f1fcaf8e0"
-  integrity sha512-9XGEogHQcYZCJp2PvLE7oDgGzIsBy4Vh28EhDS26iJFwtDVpHYm7fIzJ//SDGcUNjnlR9WKTegFLg9p7jYIQWQ==
-  dependencies:
-    fetch-cookie "0.7.0"
-    node-fetch "^2.0.0"
-
-pouchdb-find@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pouchdb-find/-/pouchdb-find-7.0.0.tgz#f390c3f7a9455e700eb178eb89b235aaf7dc3beb"
-  integrity sha512-nqAdnbmmxcIrWF//k5LKDGXaDZScgvhqVoyGjXhiUan35ASI0KYn1R8Z0nGsl0PD/DRK1kveQjbC9+50QgdTRg==
-  dependencies:
-    pouchdb-abstract-mapreduce "7.0.0"
-    pouchdb-collate "7.0.0"
-    pouchdb-errors "7.0.0"
-    pouchdb-fetch "7.0.0"
-    pouchdb-md5 "7.0.0"
-    pouchdb-selector-core "7.0.0"
-    pouchdb-utils "7.0.0"
-
-pouchdb-mapreduce-utils@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pouchdb-mapreduce-utils/-/pouchdb-mapreduce-utils-7.0.0.tgz#ff342e9d515d4c9cf0b19ad85c78f10f2568493b"
-  integrity sha512-kj74SpirbQAC7BSlBpPO42RBbUw8XmxbkLCnHyL7CVktyEn24VHbCoirutUI2mRPii7MAVHtleGKXRijR5QIpw==
-  dependencies:
-    argsarray "0.0.1"
-    inherits "2.0.3"
-    pouchdb-collections "7.0.0"
-    pouchdb-utils "7.0.0"
-
-pouchdb-md5@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pouchdb-md5/-/pouchdb-md5-7.0.0.tgz#935dc6bb507a5f3978fb653ca5790331bae67c96"
-  integrity sha512-yaSJKhLA3QlgloKUQeb2hLdT3KmUmPfoYdryfwHZuPTpXIRKTnMQTR9qCIRUszc0ruBpDe53DRslCgNUhAyTNQ==
-  dependencies:
-    pouchdb-binary-utils "7.0.0"
-    spark-md5 "3.0.0"
-
-pouchdb-selector-core@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pouchdb-selector-core/-/pouchdb-selector-core-7.0.0.tgz#824bd0980bd9778b3ddef869306a6cdb928df703"
-  integrity sha512-8Lpa8S7TCRGUEy3aEMd+Zy85IU4KwCVNf3TT+HJ8XAKICtmgArPrQGimIXFOHoyjRSpCXtByzEriP8CBCUjp7g==
-  dependencies:
-    pouchdb-collate "7.0.0"
-    pouchdb-utils "7.0.0"
-
-pouchdb-utils@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pouchdb-utils/-/pouchdb-utils-7.0.0.tgz#48bfced6665b8f5a2b2d2317e2aa57635ed1e88e"
-  integrity sha512-1bnoX1KdZYHv9wicDIFdO0PLiVIMzNDUBUZ/yOJZ+6LW6niQCB8aCv09ZztmKfSQcU5nnN3fe656tScBgP6dOQ==
-  dependencies:
-    argsarray "0.0.1"
-    clone-buffer "1.0.0"
-    immediate "3.0.6"
-    inherits "2.0.3"
-    pouchdb-collections "7.0.0"
-    pouchdb-errors "7.0.0"
-    pouchdb-md5 "7.0.0"
-    uuid "3.2.1"
-
 preact-compat@^3.17.0:
   version "3.18.0"
   resolved "https://registry.yarnpkg.com/preact-compat/-/preact-compat-3.18.0.tgz#ca430cc1f67193fb9feaf7c510832957b2ebe701"
@@ -9349,11 +9195,6 @@ psl@^1.1.24:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
   integrity sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==
 
-psl@^1.1.28:
-  version "1.1.31"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.31.tgz#e9aa86d0101b5b105cbe93ac6b784cd547276184"
-  integrity sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==
-
 public-encrypt@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
@@ -9409,7 +9250,7 @@ punycode@^1.2.4, punycode@^1.4.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
-punycode@^2.1.0, punycode@^2.1.1:
+punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
@@ -10806,11 +10647,6 @@ source-map@^0.7.3:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
-spark-md5@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.0.tgz#3722227c54e2faf24b1dc6d933cc144e6f71bfef"
-  integrity sha1-NyIifFTi+vJLHcbZM8wUTm9xv+8=
-
 spdx-correct@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.2.tgz#19bb409e91b47b1ad54159243f7312a858db3c2e"
@@ -11470,14 +11306,6 @@ tough-cookie@>=2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.4.3:
     psl "^1.1.24"
     punycode "^1.4.1"
 
-tough-cookie@^2.3.1:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
-  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
-  dependencies:
-    psl "^1.1.28"
-    punycode "^2.1.1"
-
 tr46@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
@@ -11830,11 +11658,6 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
-  integrity sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==
-
 uuid@^3.0.1, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
@@ -11947,11 +11770,6 @@ vue-template-es2015-compiler@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz#dc42697133302ce3017524356a6c61b7b69b4a18"
   integrity sha512-x3LV3wdmmERhVCYy3quqA57NJW7F3i6faas++pJQWtknWT+n7k30F4TVdHvCLn48peTJFRvCpxs3UuFPqgeELg==
-
-vuvuzela@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/vuvuzela/-/vuvuzela-1.0.3.tgz#3be145e58271c73ca55279dd851f12a682114b0b"
-  integrity sha1-O+FF5YJxxzylUnndhR8SpoIRSws=
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3409,6 +3409,11 @@ cozy-flags@1.6.1:
     detect-node "2.0.4"
     microee "^0.0.6"
 
+cozy-interapp@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/cozy-interapp/-/cozy-interapp-0.4.5.tgz#115912a389448ebb8dc532972270b46e15010063"
+  integrity sha512-CuiZ4PIrDj+jcK1sCizFNCC9r8+/sgKXLtDgkpKHRHk+q0lhvqz/fQAVPWiIsZAr9WdbfxaBfsJCoHP/41+G1Q==
+
 cozy-logger@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/cozy-logger/-/cozy-logger-1.3.1.tgz#27d9578756b318b1460a135cda94475c734b9f39"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3416,10 +3416,12 @@ cozy-logger@1.3.1:
   dependencies:
     json-stringify-safe "5.0.1"
 
-cozy-realtime@2.0.8:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-2.0.8.tgz#e2e9abfaeff8b610c2bbd1bf9cb5898484df2ef1"
-  integrity sha512-L0PAaZXT6u1ixmdMIaSsPwcX1edLZ+8AdiqdOKL+olPaMDgNseyyjr4Vlnnsr7Sx5f6BpcWQFUQr+do+yX9i+w==
+cozy-realtime@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-3.0.1.tgz#be244b4b810992b915920fd10be3c765da5bed6d"
+  integrity sha512-nlSJtIkl29Syq5RW6Y49XvVUp3gJ7Q8Y6J+qHgxinc2ftCXHWpEBvYkvsH5LN+KdHSLIbywy94cO7BHv29pZEQ==
+  dependencies:
+    minilog "3.1.0"
 
 cozy-scripts@1.13.0:
   version "1.13.0"
@@ -7772,6 +7774,13 @@ mini-css-extract-plugin@0.5.0:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
     webpack-sources "^1.1.0"
+
+minilog@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/minilog/-/minilog-3.1.0.tgz#d2d0f1887ca363d1acf0ea86d5c4df293b3fb675"
+  integrity sha1-0tDxiHyjY9Gs8OqG1cTfKTs/tnU=
+  dependencies:
+    microee "0.0.6"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
No more cozy-client-js and use new cozy-realtime. Done to facilitate
code sharing between applications.

Parts that have changed: 

- reducer des apps
- realtime
- new interapp (bad handshake if we do not use cozy-client v2)