### PR TITLE
feat: Different translation for terms with partnership

### DIFF
--- a/src/ducks/apps/components/AppInstallation.jsx
+++ b/src/ducks/apps/components/AppInstallation.jsx
@@ -19,6 +19,8 @@ import { getTranslatedManifestProperty } from 'lib/helpers'
 import { hasPendingUpdate } from 'ducks/apps/appStatus'
 import storeConfig from 'config'
 import compose from 'lodash/flowRight'
+import get from 'lodash/get'
+import pickBy from 'lodash/pickBy'
 
 import { APP_TYPE, getAppBySlug, installAppFromRegistry } from 'ducks/apps'
 import { withClient } from 'cozy-client'
@@ -115,6 +117,14 @@ export class AppInstallation extends Component {
       )
     }
 
+    const termsCheckboxTranslationOpts = pickBy(
+      {
+        url: get(app, 'terms.url'),
+        partnerName: get(app, 'partnership.name')
+      },
+      Boolean
+    )
+
     return (
       <React.Fragment>
         <ModalHeader title={t('app_modal.install.title')} />
@@ -155,9 +165,17 @@ export class AppInstallation extends Component {
                   disabled={isInstalling}
                 >
                   <ReactMarkdownWrapper
-                    source={t('app_modal.install.terms', {
-                      url: app.terms.url
-                    })}
+                    source={
+                      app.partnership
+                        ? t(
+                            'app_modal.install.termsWithPartnership',
+                            termsCheckboxTranslationOpts
+                          )
+                        : t(
+                            'app_modal.install.terms',
+                            termsCheckboxTranslationOpts
+                          )
+                    }
                   />
                 </Checkbox>
               </div>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -58,6 +58,7 @@
       "install": "Install",
       "update": "Update",
       "terms": "I have read and I accept [this application related ToS](%{url})",
+      "termsWithPartnership": "I accept [the %{partnerName} Terms of Service](%{url}) and I accept the transmission of my data to its partner Cozy Cloud. The use of the data is for individual non-professional use.",
       "message": {
         "version_error": "Something went wrong when fetching the application informations. Reason: %{message}",
         "install_error": "Something went wrong when installing the application on your Cozy. Reason: %{message}"


### PR DESCRIPTION
After an audit, BI asks us to update some of our wordings. Here, we introduce a new case for terms checkbox with partnership. With this, when an app has terms to accept and has a partnership, the terms checkbox label contains a little more informations. See below

Terms without partnership:
![image](https://user-images.githubusercontent.com/1606068/63944439-cbc03f80-ca71-11e9-9a3e-47ac2f74eebe.png)

Terms with partnership:
![image](https://user-images.githubusercontent.com/1606068/63944478-df6ba600-ca71-11e9-8e59-172e010bdfa7.png)
