### PR TITLE
chore: Fix cozyPublish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "watch:browser": "cozy-scripts watch --browser",
     "watch:mobile": "cozy-scripts watch --mobile",
     "start": "cozy-scripts start --hot",
-    "cozyPublish": "cozy-scripts publish --token $REGISTRY_TOKEN --prepublish downcloud --postpublish mattermost",
+    "cozyPublish": "npx cozy-app-publish --token $REGISTRY_TOKEN --prepublish downcloud --postpublish mattermost",
     "test": "cozy-scripts test --verbose --coverage",
     "stack:docker": "docker run --rm -it -p 8080:8080 -v \"$(pwd)/build\":/data/cozy-app/app cozy/cozy-app-dev"
   },


### PR DESCRIPTION
There is a problem with cozy-scripts' publish script that prevents us
from deploying the store to the registry. See
https://travis-ci.org/cozy/cozy-store/jobs/578391579#L570. This looks a
hard to debug issue. Using npx while we investigate this issue ensures
that the deployment is still working.