### PR TITLE
feat: Show full app developer on hover

### DIFF
--- a/src/ducks/apps/components/Sections/components/SmallAppItem.jsx
+++ b/src/ducks/apps/components/Sections/components/SmallAppItem.jsx
@@ -23,7 +23,7 @@ export const SmallAppItem = ({ t, app, name, namePrefix, onClick }) => {
           {namePrefix ? `${namePrefix} ${name}` : name}
         </h4>
         {developer.name && (
-          <p className="sto-small-app-item-developer">
+          <p className="sto-small-app-item-developer" title={developer.name}>
             {`${t('app_item.by')} ${developer.name}`}
           </p>
         )}

--- a/src/ducks/apps/components/Sections/components/__snapshots__/SmallAppItem.spec.jsx.snap
+++ b/src/ducks/apps/components/Sections/components/__snapshots__/SmallAppItem.spec.jsx.snap
@@ -39,6 +39,7 @@ exports[`SmallAppItem component should render correctly an app 1`] = `
     </h4>
     <p
       className="sto-small-app-item-developer"
+      title="Cozy"
     >
       By Cozy
     </p>
@@ -89,6 +90,7 @@ exports[`SmallAppItem component should render correctly an app in maintenance 1`
     </h4>
     <p
       className="sto-small-app-item-developer"
+      title="Naming me"
     >
       By Naming me
     </p>
@@ -142,6 +144,7 @@ exports[`SmallAppItem component should render correctly an app with iconToLoad (
     </h4>
     <p
       className="sto-small-app-item-developer"
+      title="Naming me"
     >
       By Naming me
     </p>
@@ -195,6 +198,7 @@ exports[`SmallAppItem component should render correctly an app with iconToLoad i
     </h4>
     <p
       className="sto-small-app-item-developer"
+      title="Naming me"
     >
       By Naming me
     </p>
@@ -285,6 +289,7 @@ exports[`SmallAppItem component should render correctly an installed app 1`] = `
     </h4>
     <p
       className="sto-small-app-item-developer"
+      title="Naming me"
     >
       By Naming me
     </p>
@@ -336,6 +341,7 @@ exports[`SmallAppItem component should render correctly an installed app without
     </h4>
     <p
       className="sto-small-app-item-developer"
+      title="Cozy"
     >
       By Cozy
     </p>


### PR DESCRIPTION
So one can read long family names & budget insight connectors developer.

#### Checklist

Before merging this PR, the following things must have been done:

- [x] Faithful integration of the mockups at all screen sizes → *no change except on mouse over*
- [x] Tested on supported browsers, including responsive mode (IE11 and Edge, Chrome >= 42, 2 latest versions of Firefox and Safari) → *browsers properly showing titles should work, others should still be as broken as before*
- [x] Localized in english and french → *no new text to translate*
- [x] All changes have test coverage
- [x] Updated README, if necessary → *not relevant*
- [x] Make sure commit messages rely on the [Commitizen](http://commitizen.github.io/cz-cli/) format
