### PR TITLE
fix: Remove FocusTrap on AppInstall

### DIFF
--- a/src/ducks/apps/components/InstallModal.jsx
+++ b/src/ducks/apps/components/InstallModal.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import Modal from 'cozy-ui/transpiled/react/Modal'
-import FocusTrap from 'focus-trap-react'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import Portal from 'cozy-ui/transpiled/react/Portal'
 import { withClient } from 'cozy-client'
@@ -14,7 +13,6 @@ import { fetchLatestApp, restoreAppIfSaved } from 'ducks/apps'
 export class InstallModal extends Component {
   constructor(props) {
     super(props)
-    this.state = { activeTrap: true }
   }
 
   componentDidMount = () => {
@@ -32,10 +30,6 @@ export class InstallModal extends Component {
     }
   }
 
-  unmountTrap = () => {
-    this.setState({ activeTrap: false })
-  }
-
   dismiss = () => {
     this.props.restoreAppIfSaved()
     this.props.dismissAction()
@@ -43,22 +37,16 @@ export class InstallModal extends Component {
 
   render() {
     const { app, redirectToApp, redirectToConfigure } = this.props
+
     return (
       <Portal into="body">
         <Modal dismissAction={this.dismiss} mobileFullscreen>
-          <FocusTrap
-            focusTrapOptions={{
-              onDeactivate: this.unmountTrap,
-              clickOutsideDeactivates: true
-            }}
-          >
-            <AppInstallation
-              appSlug={app.slug}
-              onCancel={this.dismiss}
-              onKonnectorInstall={redirectToConfigure}
-              onInstallOrUpdate={redirectToApp}
-            />
-          </FocusTrap>
+          <AppInstallation
+            appSlug={app.slug}
+            onCancel={this.dismiss}
+            onKonnectorInstall={redirectToConfigure}
+            onInstallOrUpdate={redirectToApp}
+          />
         </Modal>
       </Portal>
     )

--- a/test/ducks/apps/components/__snapshots__/installModal.spec.js.snap
+++ b/test/ducks/apps/components/__snapshots__/installModal.spec.js.snap
@@ -14,23 +14,10 @@ exports[`InstallModal component should be rendered correctly if app found 1`] = 
     secondaryType="secondary"
     size="small"
   >
-    <FocusTrap
-      _createFocusTrap={[Function]}
-      active={true}
-      focusTrapOptions={
-        Object {
-          "clickOutsideDeactivates": true,
-          "onDeactivate": [Function],
-        }
-      }
-      paused={false}
-      tag="div"
-    >
-      <withClient(Connect(withI18n(AppInstallation)))
-        appSlug="photos"
-        onCancel={[Function]}
-      />
-    </FocusTrap>
+    <withClient(Connect(withI18n(AppInstallation)))
+      appSlug="photos"
+      onCancel={[Function]}
+    />
   </Modal>
 </Portal>
 `;
@@ -49,23 +36,10 @@ exports[`InstallModal component should be rendered correctly to update app with 
     secondaryType="secondary"
     size="small"
   >
-    <FocusTrap
-      _createFocusTrap={[Function]}
-      active={true}
-      focusTrapOptions={
-        Object {
-          "clickOutsideDeactivates": true,
-          "onDeactivate": [Function],
-        }
-      }
-      paused={false}
-      tag="div"
-    >
-      <withClient(Connect(withI18n(AppInstallation)))
-        appSlug="photos"
-        onCancel={[Function]}
-      />
-    </FocusTrap>
+    <withClient(Connect(withI18n(AppInstallation)))
+      appSlug="photos"
+      onCancel={[Function]}
+    />
   </Modal>
 </Portal>
 `;
@@ -84,23 +58,10 @@ exports[`InstallModal component should be rendered correctly with also app in re
     secondaryType="secondary"
     size="small"
   >
-    <FocusTrap
-      _createFocusTrap={[Function]}
-      active={true}
-      focusTrapOptions={
-        Object {
-          "clickOutsideDeactivates": true,
-          "onDeactivate": [Function],
-        }
-      }
-      paused={false}
-      tag="div"
-    >
-      <withClient(Connect(withI18n(AppInstallation)))
-        appSlug="photos"
-        onCancel={[Function]}
-      />
-    </FocusTrap>
+    <withClient(Connect(withI18n(AppInstallation)))
+      appSlug="photos"
+      onCancel={[Function]}
+    />
   </Modal>
 </Portal>
 `;
@@ -119,23 +80,10 @@ exports[`InstallModal component should not break the permissions part if no perm
     secondaryType="secondary"
     size="small"
   >
-    <FocusTrap
-      _createFocusTrap={[Function]}
-      active={true}
-      focusTrapOptions={
-        Object {
-          "clickOutsideDeactivates": true,
-          "onDeactivate": [Function],
-        }
-      }
-      paused={false}
-      tag="div"
-    >
-      <withClient(Connect(withI18n(AppInstallation)))
-        appSlug="photos"
-        onCancel={[Function]}
-      />
-    </FocusTrap>
+    <withClient(Connect(withI18n(AppInstallation)))
+      appSlug="photos"
+      onCancel={[Function]}
+    />
   </Modal>
 </Portal>
 `;

--- a/test/ducks/apps/components/installModal.spec.js
+++ b/test/ducks/apps/components/installModal.spec.js
@@ -91,13 +91,6 @@ describe('InstallModal component', () => {
     expect(component).toMatchSnapshot()
   })
 
-  it('should handle focus trop correctly', () => {
-    const wrapper = shallow(<InstallModal {...getMockProps()} />)
-    expect(wrapper.state().activeTrap).toBe(true)
-    wrapper.instance().unmountTrap()
-    expect(wrapper.state().activeTrap).toBe(false)
-  })
-
   it('calls onInstalled if app installed without update', () => {
     const mockProps = getMockProps(true)
     mockProps.app.installed = true


### PR DESCRIPTION
Since our latest UI upgrade, we had to move the `FocusTrap` component inside the Modal https://github.com/cozy/cozy-store/commit/60fdca5c4332658516cf58b7622c5b68bc14bb0a#diff-44b7cb5dee073537051fb3dbc0e76da8

Because of that, in the DOM we had something like : 
```
<div class="modal">
<div>
<div class="modalheader"/>
...
</div>
</div>
```

The result was : if the content of the Modal was too long, it was displayed outside of the modal. 
<img width="284" alt="Capture d’écran 2020-06-11 à 11 52 52" src="https://user-images.githubusercontent.com/1107936/84383177-128bba00-abec-11ea-8d30-64e145314bf2.png">

We decided to remove the FocusTrap on the Modal for two things: 
- It's not part of our current QA before deploying but we can still navigate by tabbing 
- It should be done by Cozy-UI itself and not by the app 
