### PR TITLE
fix: Some hidden connectors in store

### DIFF
--- a/src/ducks/apps/client-helpers.js
+++ b/src/ducks/apps/client-helpers.js
@@ -11,7 +11,7 @@ export const fetchAppsFromChannel = (client, channel, filter) => {
   if (filter) filterParam = `&filter[type]=${filter}`
   return client.stackClient.fetchJSON(
     'GET',
-    `/registry?limit=200&versionsChannel=${channel}&latestChannelVersion=${channel}${filterParam}`
+    `/registry?limit=300&versionsChannel=${channel}&latestChannelVersion=${channel}${filterParam}`
   )
 }
 


### PR DESCRIPTION
This is due to a hardcoded limit of 200 in the request getting the list
of apps and connectors.
I set it to 300 for the weekend, but the better fix would be to add
registry to cozy-client and with a proper pagination handling.