### PR TITLE
fix: Don't force store creation

### DIFF
--- a/src/targets/intents/index.jsx
+++ b/src/targets/intents/index.jsx
@@ -21,7 +21,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const client = new CozyClient({
     uri: `${protocol}//${appData.cozyDomain}`,
     schema,
-    token: appData.cozyToken
+    token: appData.cozyToken,
+    store: false
   })
   client.registerPlugin(flag.plugin)
 


### PR DESCRIPTION
Since we pass `store` to cozyProvider, we need to set `store:false` when creating a new cozy-client 