### PR TITLE
fix: Double Scroll on some browsers

### DIFF
--- a/src/styles/application.css
+++ b/src/styles/application.css
@@ -1,5 +1,5 @@
 [role=application] {
-  overflow: hidden
+  overflow: hidden !important
 }
 
 .sto-app {


### PR DESCRIPTION
We previously added this overflow hidden
when we added the CozyTheme wrapper. I
don't know why. This overflow worked locally
but not on production since the cozy bar's
style was the one used.

Let's !important to fix the issue quickly
