### PR TITLE
feat: reword `com.bitwarden.organizations` doctype to `shared folder`

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -205,7 +205,7 @@
       "bitwarden.profiles": "Password manager profiles",
       "bitwarden.ciphers": "Password manager entries",
       "bitwarden.folders": "Password manager folders",
-      "bitwarden.organizations": "Password manager organizations",
+      "bitwarden.organizations": "Password manager shared folders",
       "grandlyon": {
         "enedis.*": "Electricity consumption data",
         "grdf.*": "Gas consumption data",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -205,7 +205,7 @@
       "bitwarden.profiles": "Profils du gestionnaire de mot de passe",
       "bitwarden.ciphers": "Entrées du gestionnaire de mot de passe",
       "bitwarden.folders": "Dossiers du gestionnaire de mot de passe",
-      "bitwarden.organizations": "Dossiers du gestionnaire de mot de passe",
+      "bitwarden.organizations": "Dossiers partagés du gestionnaire de mot de passe",
       "grandlyon": {
         "enedis.*": "Données de consommation d'électricité",
         "grdf.*": "Données de consommation de gaz",


### PR DESCRIPTION
Cozy now use bitwarden `organisations` as `folders`

Old `folder` concept has been hidden

But we may still have to manipulate `com.bitwarden.folders` so
we use distrinct `shared folder` name for `com.bitwarden.organizations`

⚠️ `src/locales/de.json` still uses `organizations` wording as I'm not sure how to translaed `shared folders`