### PR TITLE
feat: Reword `My applications` to `Installed`

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -23,11 +23,11 @@
     }
   },
   "myapps": {
-    "title": "My Applications"
+    "title": "Installed"
   },
   "nav": {
     "discover": "Applications",
-    "myapps": "My Applications"
+    "myapps": "Installed"
   },
   "soon": {
     "title": "Coming soon",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -23,11 +23,11 @@
     }
   },
   "myapps": {
-    "title": "Mes Applications"
+    "title": "Installées"
   },
   "nav": {
     "discover": "Applications",
-    "myapps": "Mes Applications"
+    "myapps": "Installées"
   },
   "soon": {
     "title": "À venir",

--- a/test/components/__snapshots__/sidebar.spec.js.snap
+++ b/test/components/__snapshots__/sidebar.spec.js.snap
@@ -37,7 +37,7 @@ exports[`Sidebar component should be rendered correctly 1`] = `
             icon="test-file-stub"
           />
           <NavText>
-            My Applications
+            Installed
           </NavText>
         </NavLink>
       </NavItem>

--- a/test/ducks/apps/components/__snapshots__/myApplications.spec.js.snap
+++ b/test/ducks/apps/components/__snapshots__/myApplications.spec.js.snap
@@ -658,7 +658,7 @@ exports[`MyApplications component should use BarCenter from cozy-bar in mobile v
       <h2
         className="sto-view-title"
       >
-        My Applications
+        Installed
       </h2>
     </BarCenter>
     <withRouter(QuerystringSections)


### PR DESCRIPTION
Previous wording was confusing and user may not understand that this
menu was about `installed` applications

`Installed application` was proposed as an alternative but this title
was too long to fit in the navbar, so we chose to use `Installed`
instead

### Before on desktop:
![image](https://user-images.githubusercontent.com/1884255/130816633-08be287b-3de5-4f53-b0ac-734916267a94.png)


### After on desktop:
![image](https://user-images.githubusercontent.com/1884255/130816570-e23110c8-1cf0-4e4c-8c97-11a698ce3018.png)


### Before on mobile:
![image](https://user-images.githubusercontent.com/1884255/130816680-5a2ff378-6634-471b-a084-22e145eeba88.png)


### After on mobile:
![image](https://user-images.githubusercontent.com/1884255/130816720-2d07f3e0-fb3b-4efa-b0b9-54b753b3d5dc.png)