### PR TITLE
feat: Reword permissions modal

### DIFF
--- a/src/ducks/apps/components/PermissionsList.jsx
+++ b/src/ducks/apps/components/PermissionsList.jsx
@@ -120,11 +120,7 @@ export const PermissionsList = ({ t, app }) => {
             color="#35CE68"
           />
           <p>
-            {externalPermissions.length
-              ? t('permissions.description.internal', { name: developerName })
-              : t('permissions.description.only_internal', {
-                  name: developerName
-                })}
+            {t('permissions.description.internal', { name: developerName })}
           </p>
         </div>
       )}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -282,7 +282,6 @@
     "reason": "**Reason: **",
     "developer_default": "The developer of this application",
     "description": {
-      "only_internal": "This app will not transmit any data to its developer %{name}, it will use it only locally in your Cozy without transmission to anyone:",
       "internal": "This app will not transmit any data to its developer %{name}, it will use it only locally in your Cozy without transmission to anyone:",
       "external": "%{name} could use and extract these data from your Cozy only for the following purposes:",
       "nothing": "%{appName} doesn't require any data access to work correctly on your Cozy."

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -282,9 +282,9 @@
     "reason": "**Reason: **",
     "developer_default": "The developer of this application",
     "description": {
-      "only_internal": "%{name} commits to not giving the data used by the application:",
-      "internal": "%{name} commits to not giving the other data used by the application:",
-      "external": "%{name} commits to giving only the following data:",
+      "only_internal": "This app will not transmit any data to its developer %{name}, it will use it only locally in your Cozy without transmission to anyone:",
+      "internal": "This app will not transmit any data to its developer %{name}, it will use it only locally in your Cozy without transmission to anyone:",
+      "external": "%{name} could use and extract these data from your Cozy only for the following purposes:",
       "nothing": "%{appName} doesn't require any data access to work correctly on your Cozy."
     }
   },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -282,7 +282,6 @@
     "reason": "**Motif : **",
     "developer_default": "Le•a développeur•se de cette application",
     "description": {
-      "only_internal": "Cette application ne transmettra aucune de ces données à son éditeur %{name}, elle les utilisera localement dans votre Cozy sans jamais les transmettre à qui que ce soit :",
       "internal": "Cette application ne transmettra aucune de ces données à son éditeur %{name}, elle les utilisera localement dans votre Cozy sans jamais les transmettre à qui que ce soit :",
       "external": "%{name} pourra utiliser et extraire de votre Cozy ces données uniquement pour les motifs suivants :",
       "nothing": "%{appName} ne requiert aucun accès à vos données pour fonctionner correctement sur votre Cozy."

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -282,9 +282,9 @@
     "reason": "**Motif : **",
     "developer_default": "Le•a développeur•se de cette application",
     "description": {
-      "only_internal": "%{name} s’engage à ne pas transmettre les données utilisées par l'application :",
-      "internal": "%{name} s’engage à ne pas transmettre les autres données utilisées par l'application :",
-      "external": "%{name} s’engage à transmettre uniquement les données suivantes :",
+      "only_internal": "Cette application ne transmettra aucune de ces données à son éditeur %{name}, elle les utilisera localement dans votre Cozy sans jamais les transmettre à qui que ce soit :",
+      "internal": "Cette application ne transmettra aucune de ces données à son éditeur %{name}, elle les utilisera localement dans votre Cozy sans jamais les transmettre à qui que ce soit :",
+      "external": "%{name} pourra utiliser et extraire de votre Cozy ces données uniquement pour les motifs suivants :",
       "nothing": "%{appName} ne requiert aucun accès à vos données pour fonctionner correctement sur votre Cozy."
     }
   },

--- a/test/ducks/apps/components/__snapshots__/permissionsList.spec.js.snap
+++ b/test/ducks/apps/components/__snapshots__/permissionsList.spec.js.snap
@@ -16,7 +16,7 @@ exports[`PermissionsList component should be rendered correctly with konnector p
       spin={false}
     />
     <p>
-      Cozy commits to not giving the data used by the application:
+      This app will not transmit any data to its developer Cozy, it will use it only locally in your Cozy without transmission to anyone:
     </p>
   </div>
   <ul
@@ -459,7 +459,7 @@ exports[`PermissionsList component should be rendered correctly with permissions
       spin={false}
     />
     <p>
-      Cozy commits to not giving the data used by the application:
+      This app will not transmit any data to its developer Cozy, it will use it only locally in your Cozy without transmission to anyone:
     </p>
   </div>
   <ul


### PR DESCRIPTION
Permission modal was not clear enough about what was shared or not

We think that the new wording will fix this problem

### Before:
![image](https://user-images.githubusercontent.com/1884255/130817235-2372cba6-379f-4304-ae4a-38680aadcfb7.png)

### After:
![image](https://user-images.githubusercontent.com/1884255/130817152-bdce4d2c-cb4a-4ebb-bc23-41bf0b394948.png)
