### PR TITLE
fix: Make the main content fill the remain space of the browser view

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "cozy-interapp": "0.6.2",
     "cozy-logger": "1.3.1",
     "cozy-realtime": "3.10.5",
-    "cozy-ui": "^50.1.2",
+    "cozy-ui": "^51.7.1",
     "dom-helpers": "^5.2.0",
     "emoji-js": "3.4.1",
     "focus-trap-react": "4.0.1",

--- a/src/ducks/components/Root.jsx
+++ b/src/ducks/components/Root.jsx
@@ -10,7 +10,7 @@ import App from 'ducks/components/App'
 
 const Root = ({ client, lang, store }) => {
   return (
-    <CozyTheme variant="normal">
+    <CozyTheme variant="normal" className="u-flex-grow-1">
       <I18n lang={lang} dictRequire={lang => require(`locales/${lang}`)}>
         <CozyProvider client={client}>
           <Provider store={store}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3212,10 +3212,10 @@ cozy-ui@35.22.0:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@^50.1.2:
-  version "50.1.2"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-50.1.2.tgz#030aab0d5f1bae83f2ca36a7a790eabf4d1baa44"
-  integrity sha512-tFCMaN4DtbRdx5LDPeCvsa1h97IVFv49WOTLp01b3C7oSxGCMzjuoMY1GXMj/eYzeYs+bqR1qOepXv/ZXdjckw==
+cozy-ui@^51.7.1:
+  version "51.7.1"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-51.7.1.tgz#3ca58b7fa1f0cdbf47d3e26cb040c5755e336800"
+  integrity sha512-EumKAp+NQoT/gZ6rGClwnv69SaIcCds5XG15PLj5Qso0EWkZoUnt6tAIJqwUwLpSgiYvYhuvDTb5Qnzqiu8iRA==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"


### PR DESCRIPTION
⚠️ this PR is a draft as it should be completed by bumping `cozy-ui` version after related PR is merged

When the main content (application list) is scrollable but its content is not large enough (i.e. a few apps in each list section), then the scroll bar is stick to the apps list instead of being stick to the browser right side

This fix make the main content always take all remaining space

`u-flex-grow-1` has been added to `<CozyTheme>` as this is the first child directly under the main application container (which is set to be a flexbox)

Also the scrollable area highly depends on navbar size, this has been fixed in cozy-ui with https://github.com/cozy/cozy-ui/pull/1881 

### Before:
![image](https://user-images.githubusercontent.com/1884255/131012432-83c07837-e6fa-45ed-bc8e-5ade12a69d1d.png)

### After:
![image](https://user-images.githubusercontent.com/1884255/131012382-21a377d5-eea4-4c20-a4a5-97d5b7f04945.png)
