### PR TITLE
feat: remove `open` button's icon

### DIFF
--- a/src/ducks/apps/components/ApplicationPage/Header.jsx
+++ b/src/ducks/apps/components/ApplicationPage/Header.jsx
@@ -60,14 +60,12 @@ export const Header = ({
                 })
               }}
               className="c-btn"
-              icon="openwith"
               label={t('app_page.konnector.open')}
             />
           ) : (
             <Button
               onClick={() => openApp(related)}
               className="c-btn"
-              icon="openwith"
               label={t('app_page.webapp.open')}
             />
           )


### PR DESCRIPTION
The `openwith` icon is used as an indication that the link will leave
the cozy domain. Here we are removing this icon to avoir confusion as
the `open` button stay inside of the cozy and inside of the same tab

### Before:
![image](https://user-images.githubusercontent.com/1884255/131086658-5e224472-5c1d-4568-ae84-89634e405852.png)


### After:
![image](https://user-images.githubusercontent.com/1884255/131086592-f43a248f-0911-41b9-a2a1-d518dfef36b7.png)
