### PR TITLE
fix: fix permission list category to have fixed icon size

### DIFF
--- a/src/styles/permissions.css
+++ b/src/styles/permissions.css
@@ -8,6 +8,7 @@
 .sto-perm-list-title p {
   margin: 0;
   line-height: 1.5;
+  flex: 1 1 100%;
 }
 
 .sto-perm-list-icon {


### PR DESCRIPTION
In Permissionlist categories, icon size was affected by the category
text's length

Now the text block doesn't grow and so icon cannot be shrink and always
has the desired size

### Before:
![image](https://user-images.githubusercontent.com/1884255/131531068-887e394d-487b-40c6-ba98-d647ddcf3c84.png)

### After:
![image](https://user-images.githubusercontent.com/1884255/131531044-a8b10f4d-ee71-49f8-a25f-3097a2a1c62f.png)
