### PR TITLE
fix: Use correct CozyData membres in intent

### DIFF
--- a/src/ducks/components/intents/InstallAppIntent.jsx
+++ b/src/ducks/components/intents/InstallAppIntent.jsx
@@ -117,9 +117,9 @@ export class InstallAppIntent extends Component {
     return (
       <div className="coz-intent-wrapper">
         <IntentHeader
-          appEditor={appData.cozyAppEditor}
-          appName={appData.cozyAppName}
-          appIcon={`../${appData.cozyIconPath}`}
+          appEditor={appData.app.editor}
+          appName={appData.app.name}
+          appIcon={`../${appData.app.icon}`}
         />
         <div className={`coz-intent-content${fetching ? ' --loading' : ''}`}>
           {fetching && <Spinner size="xxlarge" noMargin />}

--- a/test/components/intents/installAppIntent.spec.js
+++ b/test/components/intents/installAppIntent.spec.js
@@ -17,9 +17,11 @@ describe('InstallAppIntent component', () => {
       slug: 'drive'
     },
     appData: {
-      cozyAppEditor: 'Cozy',
-      cozyAppName: 'Drive',
-      cozyIconPath: '/path/to/icon'
+      app: {
+        editor: 'Cozy',
+        name: 'Drive',
+        icon: '/path/to/icon'
+      }
     },
     initAppIntent: jest.fn()
   }


### PR DESCRIPTION
Previous commit that refactored CozyData usage forgot some refactoring in `installAppIntent`

Related commit: 5d3659bfba0680e6413ad256411be1f27a32be45