### PR TITLE
fix: Fix parsing of CozyData in intent

### DIFF
--- a/src/targets/intents/index.jsx
+++ b/src/targets/intents/index.jsx
@@ -15,7 +15,7 @@ import schema from 'lib/schema'
 
 document.addEventListener('DOMContentLoaded', () => {
   const root = document.querySelector('[role=application]')
-  const appData = root.dataset
+  const appData = JSON.parse(root.dataset.cozy)
 
   const protocol = window.location.protocol
   const client = new CozyClient({


### PR DESCRIPTION
Previous commit that refactored CozyData usage forgot some refactoring
in `intents/index.jsx`

Related commit: 5d3659bfba0680e6413ad256411be1f27a32be45
and f5c6deb970ca5db3866164555a0837726583ba0d