### PR TITLE
feat: Bump cozy-ui to 51.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add new doctypes ([PR #745](https://github.com/cozy/cozy-store/pull/745) and [PR #752](https://github.com/cozy/cozy-store/pull/752))
 * Remove `open` button's icon ([PR #748](https://github.com/cozy/cozy-store/pull/748))
 * Improve permissions modal to correctly display remote doctypes ([PR #750](https://github.com/cozy/cozy-store/pull/750))
+* Improve UI of App tiles to ease visualisation of installed apps, updatable apps and support multiline title ([PR #763](https://github.com/cozy/cozy-store/pull/763))
 
 ## 🐛 Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "cozy-interapp": "0.6.2",
     "cozy-logger": "1.3.1",
     "cozy-realtime": "3.10.5",
-    "cozy-ui": "^51.7.1",
+    "cozy-ui": "^51.9.0",
     "dom-helpers": "^5.2.0",
     "emoji-js": "3.4.1",
     "focus-trap-react": "4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3212,10 +3212,10 @@ cozy-ui@35.22.0:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@^51.7.1:
-  version "51.7.1"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-51.7.1.tgz#3ca58b7fa1f0cdbf47d3e26cb040c5755e336800"
-  integrity sha512-EumKAp+NQoT/gZ6rGClwnv69SaIcCds5XG15PLj5Qso0EWkZoUnt6tAIJqwUwLpSgiYvYhuvDTb5Qnzqiu8iRA==
+cozy-ui@^51.9.0:
+  version "51.9.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-51.9.0.tgz#18df71e406b2c8f0ae6181dac70f745f1f33c83b"
+  integrity sha512-ihksI9UuCquVMbsV+Fx0npEc8pt57fxQjyRAFis9v4+v42yOo4dPrl4FkKTPMQ4s9MPP6bE4rq/0vnt+H3i+Kw==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"


### PR DESCRIPTION
This version contains new styles for `AppTiles` regarding if the app is
installed, has an update or has a title that can fit in two lines

Related PR : cozy/cozy-ui#1884 and cozy/cozy-ui#1885