### PR TITLE
chore: Bump version to 1.9.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-store",
-  "version": "1.9.10",
+  "version": "1.9.11",
   "main": "src/index.jsx",
   "scripts": {
     "deploy": "env HUSKY_SKIP_HOOKS=1 git-directory-deploy --directory build/ --branch=${DEPLOY_BRANCH:-build} --repo=${DEPLOY_REPOSITORY:-origin}",


### PR DESCRIPTION
To have next dev version visible

For now installing registry://store/dev channel gives us the same version as the stable channel