### PR TITLE
feat: use cozy-intent instead of konnectorOpenUri

### DIFF
--- a/src/ducks/apps/components/ApplicationPage/index.jsx
+++ b/src/ducks/apps/components/ApplicationPage/index.jsx
@@ -161,7 +161,6 @@ export class ApplicationPage extends Component {
               name={appName}
               description={appShortDesc}
               parent={parent}
-              konnectorOpenUri={this.props.konnectorOpenUri}
             />
             {app.screenshots && !!app.screenshots.length && (
               <Gallery slug={slug} images={app.screenshots} />

--- a/src/ducks/apps/components/ApplicationRouting/InstallRoute.jsx
+++ b/src/ducks/apps/components/ApplicationRouting/InstallRoute.jsx
@@ -3,13 +3,7 @@ import { Route } from 'react-router-dom'
 
 import InstallModal from 'ducks/apps/components/InstallModal'
 
-export const InstallRoute = ({
-  getApp,
-  isFetching,
-  parent,
-  redirectTo,
-  konnectorOpenUri
-}) => (
+export const InstallRoute = ({ getApp, isFetching, parent, redirectTo }) => (
   <Route
     path={`/${parent}/:appSlug/install`}
     render={({ match }) => {
@@ -29,7 +23,7 @@ export const InstallRoute = ({
           app={app}
           onInstalled={redirectToApp}
           dismissAction={redirectToApp}
-          redirectToConfigure={konnectorOpenUri ? null : redirectToConfigure}
+          redirectToConfigure={redirectToConfigure}
           redirectToApp={redirectToApp}
         />
       )

--- a/src/ducks/apps/components/ApplicationRouting/index.jsx
+++ b/src/ducks/apps/components/ApplicationRouting/index.jsx
@@ -43,7 +43,6 @@ export class ApplicationRouting extends Component {
                 getApp={this.getAppFromMatchOrSlug}
                 redirectTo={this.redirectTo}
                 mainPageRef={this.mainPage}
-                konnectorOpenUri={this.props.konnectorOpenUri}
               />
             )
           }}
@@ -59,7 +58,6 @@ export class ApplicationRouting extends Component {
           isFetching={isFetching}
           parent={parent}
           redirectTo={this.redirectTo}
-          konnectorOpenUri={this.props.konnectorOpenUri}
         />
         <UninstallRoute
           getApp={this.getAppFromMatchOrSlug}

--- a/src/ducks/apps/components/Discover.jsx
+++ b/src/ducks/apps/components/Discover.jsx
@@ -8,7 +8,6 @@ import { Content } from 'cozy-ui/transpiled/react/Layout'
 import ApplicationRouting from 'ducks/apps/components/ApplicationRouting'
 import Sections from 'ducks/apps/components/QuerystringSections'
 import AppsLoading from 'ducks/components/AppsLoading'
-import get from 'lodash/get'
 //import AppVote from 'ducks/components/AppVote'
 
 const { BarCenter } = cozy.bar
@@ -18,14 +17,6 @@ export class Discover extends Component {
     super(props)
     this.onAppClick = this.onAppClick.bind(this)
     this.pushQuery = this.pushQuery.bind(this)
-
-    const konnectorOpenUri = new URLSearchParams(
-      get(document.location, 'search')
-    ).get('konnector_open_uri')
-    this.state = {}
-    if (konnectorOpenUri) {
-      this.state.konnectorOpenUri = konnectorOpenUri
-    }
   }
 
   onAppClick(appSlug) {
@@ -85,7 +76,6 @@ export class Discover extends Component {
           isUninstalling={isUninstalling}
           actionError={actionError}
           parent="discover"
-          konnectorOpenUri={this.state.konnectorOpenUri}
         />
       </Content>
     )


### PR DESCRIPTION
Old `konnectorOpenUri` mechanisme is removed in favor of cozy-intent
based one

Those mechanisms are used to tell parent react-native app that a
connector pane needs to be opened

`konnectorOpenUri` required the parent react-native app to inject a
token in the store's url so the store would know if executed in a
react-native context or not, and then intercept navigation URLs to
detect if a connector needs to be opened. This implementation was not
easy to understand

New implementation uses cozy-device-helper to detect if run from
CozyFlagship app and the uses cozy-intent messaging service to ask for
displaying a connector

---

TODO:

- [x] Update Cozy-intent to retrieve dependency injection from https://github.com/cozy/cozy-libs/pull/1438