### PR TITLE
feat: Add locales and icon for eu.mycozy.dacc remote doctype

### DIFF
--- a/src/config/permissionsIcons.json
+++ b/src/config/permissionsIcons.json
@@ -18,6 +18,7 @@
   "fr.maif.maifuser.paymentterms": "files-pen",
   "fr.maif.maifuser.sinistre": "sinister",
   "fr.maif.maifuser.societaire": "profile",
+  "eu.mycozy.dacc": "energybreakdown",
   "io.cozy.accounts": "accounts",
   "io.cozy.apps": "apps",
   "io.cozy.apps.suggestions": "apps",

--- a/src/config/remote-doctypes.json
+++ b/src/config/remote-doctypes.json
@@ -7,6 +7,7 @@
   "com.deezer.api.track",
   "com.googleapis.maps",
   "com.omdbapi.img",
+  "eu.mycozy.dacc",
   "org.ecolyo.dju",
   "org.mps.share",
   "org.mps.share.rec",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -218,7 +218,12 @@
       "cozycloud": {
         "autocategorization": "Categorization model enrichment file",
         "sentry": "The application logs",
-        "dacc": "Anonymous aggregate statistics"
+        "dacc": "Anonymous aggregated statistics"
+      }
+    },
+    "eu": {
+      "mycozy": {
+        "dacc": "Anonymous aggregated statistics"
       }
     },
     "io": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -221,6 +221,11 @@
         "dacc": "Statistiques agrégées anonymes"
       }
     },
+    "eu": {
+      "mycozy": {
+        "dacc": "Statistiques agrégées anonymes"
+      }
+    },
     "io": {
       "cozy": {
         "accounts": "Identifiants",


### PR DESCRIPTION
This will be used for apps sending measures to the .eu DACC
