### PR TITLE
Feat/persist state

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "redux": "4",
     "redux-logger": "3.0.6",
     "redux-mock-store": "1.5.4",
+    "redux-persist": "^6.0.0",
     "redux-raven-middleware": "1.2.0",
     "redux-thunk": "2.3.0",
     "sinon": "7.4.2",

--- a/src/ducks/apps/reducers.js
+++ b/src/ducks/apps/reducers.js
@@ -142,7 +142,7 @@ export const isFetching = (state = false, action = {}) => {
   switch (action.type) {
     case LOADING_APP:
     case FETCH_APPS:
-      return true
+      return action.showFetching !== undefined ? action.showFetching : true
     case FETCH_APPS_SUCCESS:
     case FETCH_APPS_FAILURE:
       return false

--- a/src/ducks/components/Root.jsx
+++ b/src/ducks/components/Root.jsx
@@ -3,22 +3,25 @@ import { Provider } from 'react-redux'
 import { I18n } from 'cozy-ui/transpiled/react/I18n'
 import CozyTheme from 'cozy-ui/transpiled/react/CozyTheme'
 import PiwikHashRouter from 'lib/PiwikHashRouter'
+import { PersistGate } from 'redux-persist/integration/react'
 
 import { CozyProvider } from 'cozy-client'
 import { WebviewIntentProvider } from 'cozy-intent'
 
 import App from 'ducks/components/App'
 
-const Root = ({ client, lang, store }) => {
+const Root = ({ client, lang, store, persistor }) => {
   return (
     <WebviewIntentProvider>
       <CozyTheme variant="normal" className="u-flex-grow-1">
         <I18n lang={lang} dictRequire={lang => require(`locales/${lang}`)}>
           <CozyProvider client={client}>
             <Provider store={store}>
-              <PiwikHashRouter>
-                <App />
-              </PiwikHashRouter>
+              <PersistGate loading={null} persistor={persistor}>
+                <PiwikHashRouter>
+                  <App />
+                </PiwikHashRouter>
+              </PersistGate>
             </Provider>
           </CozyProvider>
         </I18n>

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -6,12 +6,12 @@ import storage from 'redux-persist/lib/storage' // defaults to localStorage for 
 import appReducers from 'ducks'
 import { createLogger } from 'redux-logger'
 import flag from 'cozy-flags'
+import { isFlagshipApp } from 'cozy-device-helper'
 import {
   shouldEnableTracking,
   getTracker,
   createTrackerMiddleware
 } from 'cozy-ui/transpiled/react/helpers/tracker'
-import { isFlagshipApp } from 'cozy-device-helper'
 
 const loggerMiddleware = createLogger()
 

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -1,5 +1,7 @@
 import { createStore, applyMiddleware, compose } from 'redux'
 import thunkMiddleware from 'redux-thunk'
+import { persistStore, persistReducer } from 'redux-persist'
+import storage from 'redux-persist/lib/storage' // defaults to localStorage for web
 
 import appReducers from 'ducks'
 import { createLogger } from 'redux-logger'
@@ -9,10 +11,21 @@ import {
   getTracker,
   createTrackerMiddleware
 } from 'cozy-ui/transpiled/react/helpers/tracker'
+import { isFlagshipApp } from 'cozy-device-helper'
 
 const loggerMiddleware = createLogger()
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
+const persistConfig = {
+  key: 'root',
+  storage
+}
+let reducers = ''
+if (isFlagshipApp() || flag('store.redux-persist')) {
+  reducers = persistReducer(persistConfig, appReducers)
+} else {
+  reducers = appReducers
+}
 
 const middlewares = [
   thunkMiddleware,
@@ -25,7 +38,11 @@ if (shouldEnableTracking() && getTracker()) {
   middlewares.push(createTrackerMiddleware())
 }
 
-export default createStore(
-  appReducers,
-  composeEnhancers(applyMiddleware.apply(null, middlewares))
-)
+export default () => {
+  let store = createStore(
+    reducers,
+    composeEnhancers(applyMiddleware.apply(null, middlewares))
+  )
+  let persistor = persistStore(store)
+  return { store, persistor }
+}

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -12,11 +12,17 @@ import flag from 'cozy-flags'
 
 import reduxConfig from 'lib/store'
 import schema from 'lib/schema'
+let configRedux = reduxConfig()
 
 const renderApp = function({ client, lang, configRedux }) {
   const Root = require('ducks/components/Root').default
   render(
-    <Root client={client} store={configRedux.store} lang={lang} />,
+    <Root
+      client={client}
+      store={configRedux.store}
+      lang={lang}
+      persistor={configRedux.persistor}
+    />,
     document.querySelector('[role=application]')
   )
 }
@@ -48,12 +54,11 @@ document.addEventListener('DOMContentLoaded', () => {
     lang: data.locale,
     replaceTitleOnMobile: true
   })
-  const configRedux = reduxConfig()
 
   renderApp({ client, lang, configRedux })
 })
 
 if (module.hot) {
-  renderApp({ client, lang })
+  renderApp({ client, lang, configRedux })
   module.hot.accept()
 }

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -10,13 +10,13 @@ import { render } from 'react-dom'
 import CozyClient from 'cozy-client'
 import flag from 'cozy-flags'
 
-import store from 'lib/store'
+import reduxConfig from 'lib/store'
 import schema from 'lib/schema'
 
-const renderApp = function({ client, lang }) {
+const renderApp = function({ client, lang, configRedux }) {
   const Root = require('ducks/components/Root').default
   render(
-    <Root client={client} store={store} lang={lang} />,
+    <Root client={client} store={configRedux.store} lang={lang} />,
     document.querySelector('[role=application]')
   )
 }
@@ -48,8 +48,9 @@ document.addEventListener('DOMContentLoaded', () => {
     lang: data.locale,
     replaceTitleOnMobile: true
   })
+  const configRedux = reduxConfig()
 
-  renderApp({ client, lang })
+  renderApp({ client, lang, configRedux })
 })
 
 if (module.hot) {

--- a/src/targets/intents/index.jsx
+++ b/src/targets/intents/index.jsx
@@ -3,7 +3,7 @@ import 'styles'
 import { Provider } from 'react-redux'
 import React from 'react'
 import { render } from 'react-dom'
-import store from 'lib/store'
+import reduxConfig from 'lib/store'
 
 import CozyClient, { CozyProvider } from 'cozy-client'
 import I18n from 'cozy-ui/transpiled/react/I18n'
@@ -25,14 +25,14 @@ document.addEventListener('DOMContentLoaded', () => {
     store: false
   })
   client.registerPlugin(flag.plugin)
-
+  const configRedux = reduxConfig()
   render(
     <I18n
       lang={appData.locale}
       dictRequire={lang => require(`../../locales/${lang}`)}
     >
-      <CozyProvider store={store} client={client}>
-        <Provider store={store}>
+      <CozyProvider store={configRedux.store} client={client}>
+        <Provider store={configRedux.store}>
           <IntentHandler appData={appData}>
             <InstallAppIntent action="INSTALL" type="io.cozy.apps" />
           </IntentHandler>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10495,6 +10495,11 @@ redux-persist@5.10.0:
   resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-5.10.0.tgz#5d8d802c5571e55924efc1c3a9b23575283be62b"
   integrity sha512-sSJAzNq7zka3qVHKce1hbvqf0Vf5DuTVm7dr4GtsqQVOexnrvbV47RWFiPxQ8fscnyiuWyD2O92DOxPl0tGCRg==
 
+redux-persist@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
+  integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
+
 redux-raven-middleware@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/redux-raven-middleware/-/redux-raven-middleware-1.2.0.tgz#50d02dd653cf93d2df18c4652149f1009bbbe33d"


### PR DESCRIPTION
The idea is to persist redux's state in order to display the page ASAP without spinner. 

For now it's only enabled on flagship app and with a flag since we persist data in the browser. 

I have done the strict minimum: I updated the fetchApp logic to not send "isLoading" state when the persistence is done. Also, I added a `PersistGate` with a `null` component to do not mount the app while the state is not hydrated. 