### PR TITLE
feat: Add cc.cozycloud.errors permission

### DIFF
--- a/src/config/permissionsIcons.json
+++ b/src/config/permissionsIcons.json
@@ -1,6 +1,7 @@
 {
   "cc.cozycloud.autocategorization": "category",
   "cc.cozycloud.dacc": "energybreakdown",
+  "cc.cozycloud.errors": "bug-report",
   "cc.cozycloud.sentry": "bug-report",
   "com.bitwarden.profiles": "passwords",
   "com.bitwarden.ciphers": "passwords",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -217,6 +217,7 @@
     "cc": {
       "cozycloud": {
         "autocategorization": "Categorization model enrichment file",
+        "errors": "The application logs",
         "sentry": "The application logs",
         "dacc": "Anonymous aggregated statistics"
       }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -217,6 +217,7 @@
     "cc": {
       "cozycloud": {
         "autocategorization": "Fichier d'enrichissement du modèle de catégorisation",
+        "errors": "Journaux de l'application",
         "sentry": "Journaux de l'application",
         "dacc": "Statistiques agrégées anonymes"
       }


### PR DESCRIPTION
Since `cc.cozycloud.sentry` is deprecated, we are migrating to `cc.cozycloud.errors`. So let's add this permission 