### PR TITLE
feat: Upgrade cozy-client to 30.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.9.12
+
+## 🔧 Tech
+
+* Upgrade cozy-client to get ability to force HTTPs fetches when `window.cozy.isSecureProtocol` is `true`
+
 # 1.9.11
 
 ## ✨ Features

--- a/package.json
+++ b/package.json
@@ -41,11 +41,12 @@
     "stylint": "2.0.0"
   },
   "dependencies": {
+    "@cozy/minilog": "^1.0.0",
     "@material-ui/core": "4.12.3",
     "@testing-library/react": "11.2.7",
     "cozy-app-publish": "^0.27.2",
     "cozy-bar": "^7.17.1",
-    "cozy-client": "^27.19.4",
+    "cozy-client": "^30.0.0",
     "cozy-device-helper": "^2.1.0",
     "cozy-doctypes": "1.72.2",
     "cozy-flags": "2.8.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3832,19 +3832,16 @@ cozy-client@^27.14.4:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^27.19.4:
-  version "27.19.4"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-27.19.4.tgz#d7bdb2753993f95827c9660b7ee620fd7f45bfa4"
-  integrity sha512-k6h6YHgnnauMCcbs+ZTRIJ32RemzqQTLVlVs7kmNMJpOL5Ke8LDSYmRdxO3CpxULM+GJanDgVsmN3gDSMQkVLQ==
+cozy-client@^30.0.0:
+  version "30.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-30.0.0.tgz#9e47137451ac61ca75baff4b099b5f5761c80d59"
+  integrity sha512-7TnBmL2QNdaXVl34NG2VJgRqKkKbGUJR6lQLcg/WRN+Ghh8PQXDzyBcsxlWme4KOIZcQyPwsCkCOImUJNHeDdQ==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-device-helper "^1.12.0"
-    cozy-flags "2.7.1"
-    cozy-logger "^1.6.0"
-    cozy-stack-client "^27.19.4"
+    cozy-stack-client "^30.0.0"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
     microee "^0.0.6"
@@ -4027,22 +4024,21 @@ cozy-scripts@^6.3.1:
     webpack-dev-server "3.10.3"
     webpack-merge "4.2.2"
 
-cozy-stack-client@^27.19.4:
-  version "27.19.4"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-27.19.4.tgz#3d27b4b9b2528e564ba7c82465288500d6e2d713"
-  integrity sha512-LyqqC6axHRA/ryGxiEb93RgJQo1SHQClQVzk4vfniZvBEGAGo6jKEDntA+/2pcIvEG/PJKUO9SY2YYydcLksNw==
-  dependencies:
-    cozy-flags "2.7.1"
-    detect-node "^2.0.4"
-    mime "^2.4.0"
-    qs "^6.7.0"
-
 cozy-stack-client@^27.26.0:
   version "27.26.0"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-27.26.0.tgz#153b32411c7e8480db7c7a01621999f4969294a7"
   integrity sha512-UO+1DdPLntkw1aI0XVgME/ChkInjltiy5w7z83OkVlkBZ3tXwLckzh3bXcUdR0TfIwv4fsCWCOJb/gIUFo0fFA==
   dependencies:
     cozy-flags "2.7.1"
+    detect-node "^2.0.4"
+    mime "^2.4.0"
+    qs "^6.7.0"
+
+cozy-stack-client@^30.0.0:
+  version "30.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-30.0.0.tgz#f53a48112a273b8bac7aa9b83f4f3643ed0eec73"
+  integrity sha512-B+E5bnwvmfDeGVvS29YB6FdNzEqWlL87fuS3XKIE0tYsWZPujI7dr45ma3hYj4S329sxDX7hC/Ya6lYKqwCj9w==
+  dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"
     qs "^6.7.0"
@@ -8829,9 +8825,9 @@ ms@^2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
+"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
   version "1.0.6"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
+  resolved "https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
This version retrieves a feature that allow `cozy-client` to force
HTTPs on fetches if `window.cozy.isSecureProtocol` is `true` (which
should be the case when `cozy-home` is served from ReactNative)

Related PR: cozy/cozy-client#1172
