### PR TITLE
fix: Update search text placeholder

### DIFF
--- a/src/ducks/apps/components/Sections/index.spec.jsx
+++ b/src/ducks/apps/components/Sections/index.spec.jsx
@@ -70,7 +70,7 @@ describe('Search', () => {
 
   it('should filter the results', async () => {
     const { root } = setup()
-    const input = root.getByPlaceholderText('"SNCF", "telecom", "bills"')
+    const input = root.getByPlaceholderText('"Ameli", "telecom", "bills"')
 
     act(() => {
       fireEvent.change(input, { target: { value: 'Bouil' } })

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -308,6 +308,6 @@
 
   "discover-search-field": {
     "label": "Search:",
-    "placeholder": "\"SNCF\", \"telecom\", \"bills\""
+    "placeholder": "\"Ameli\", \"telecom\", \"bills\""
   }
 }


### PR DESCRIPTION
At the moment, the SNCF konnector is in maintenance. So we need to display another konnector in the placeholder.

I updated only the source language (EN), and updated the 2 others (FR, DE) on Transifex. Is it the good way to do ?