### PR TITLE
fix: Hide app under maintenance by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@testing-library/react": "11.2.7",
     "cozy-app-publish": "^0.27.2",
     "cozy-bar": "^7.19.1",
-    "cozy-client": "^34.2.0",
+    "cozy-client": "^34.5.0",
     "cozy-device-helper": "^2.1.0",
     "cozy-doctypes": "1.85.0",
     "cozy-flags": "2.8.7",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "cozy-interapp": "0.7.4",
     "cozy-logger": "1.9.0",
     "cozy-realtime": "3.14.4",
-    "cozy-ui": "^77.10.0",
+    "cozy-ui": "^79.0.0",
     "emoji-js": "3.7.0",
     "focus-trap-react": "4.0.1",
     "fuse.js": "6.5.3",

--- a/src/ducks/apps/components/QuerystringSections.jsx
+++ b/src/ducks/apps/components/QuerystringSections.jsx
@@ -39,7 +39,12 @@ const parseURLSearchParams = urlParams => {
 
 const getFilterFromQuery = query => {
   const usp = new URLSearchParams(query)
-  return omit(parseURLSearchParams(usp), FILTER_BLACK_LIST)
+  const params = parseURLSearchParams(usp)
+  // Add showMaintenance by default to false
+  if (params.showMaintenance == undefined) {
+    params.showMaintenance = false
+  }
+  return omit(params, FILTER_BLACK_LIST)
 }
 
 const queryFromFilter = filter => {
@@ -66,7 +71,7 @@ class QuerystringSections extends React.Component {
     }
   }
 
-  componentWillUpdate(nextProps) {
+  UNSAFE_componentWillUpdate(nextProps) {
     if (this.props.location !== nextProps.location) {
       this.setState({
         filter: getFilterFromQuery(nextProps.location.search)

--- a/src/ducks/apps/components/Sections/components/Filters.jsx
+++ b/src/ducks/apps/components/Sections/components/Filters.jsx
@@ -10,18 +10,14 @@ import SettingIcon from 'cozy-ui/transpiled/react/Icons/Setting'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
-import { useEffect } from 'react'
 
 const { BarRight } = cozy.bar
 
 const Filters = ({ filter, onFilterChange }) => {
   const anchorRef = useRef()
   const [menuDisplayed, setMenuDisplayed] = useState(false)
-  const [appUnderMaintenance, setAppUnderMaintenance] = useState(true)
 
-  useEffect(() => {
-    setAppUnderMaintenance(filter.underMaintenance == undefined)
-  }, [filter.underMaintenance])
+  const areAppsUnderMaintenanceShown = filter.showMaintenance
 
   const toggleMenu = () => {
     setMenuDisplayed(!menuDisplayed)
@@ -32,17 +28,19 @@ const Filters = ({ filter, onFilterChange }) => {
   }
 
   const showAppUnderMaintenance = () => {
-    delete filter.underMaintenance
-    onFilterChange({
-      ...filter
-    })
+    if (!areAppsUnderMaintenanceShown) {
+      onFilterChange({
+        ...filter,
+        showMaintenance: true
+      })
+    }
   }
 
   const hideAppUnderMaintenance = () => {
-    onFilterChange({
-      ...filter,
-      underMaintenance: false
-    })
+    if (areAppsUnderMaintenanceShown) {
+      delete filter.showMaintenance
+      onFilterChange(filter)
+    }
   }
 
   const { isMobile } = useBreakpoints()
@@ -81,13 +79,13 @@ const Filters = ({ filter, onFilterChange }) => {
         >
           <ActionMenuItem
             onClick={showAppUnderMaintenance}
-            left={<ActionMenuRadio checked={appUnderMaintenance} />}
+            left={<ActionMenuRadio checked={areAppsUnderMaintenanceShown} />}
           >
             {t('sections.filters.under_maintenance.show')}
           </ActionMenuItem>
           <ActionMenuItem
             onClick={hideAppUnderMaintenance}
-            left={<ActionMenuRadio checked={!appUnderMaintenance} />}
+            left={<ActionMenuRadio checked={!areAppsUnderMaintenanceShown} />}
           >
             {t('sections.filters.under_maintenance.hide')}
           </ActionMenuItem>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4083,10 +4083,10 @@ cozy-ui@22.3.1:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
-cozy-ui@^77.10.0:
-  version "77.10.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-77.10.0.tgz#2c1de58049b01cda9890a1ab1ecf86172f45328b"
-  integrity sha512-68kTwnC0uwy5KBK/HHDT+BL5SG5IksXFdo1+5HWFVP/sihcZlV6PqtHNsznb5eMSmEOAKABIgtHAEUiARhbUlw==
+cozy-ui@^79.0.0:
+  version "79.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-79.0.0.tgz#1e3a0c22e3c8a0f16900bb3013787414b7a98e69"
+  integrity sha512-89cjOTqdEzqR51F8bawyYmWbB+Pvnc/WavxbkiRni8rxLRnj36FLTTXLuENiib+bAZf9HulZFnrNfB5cZMKTEw==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"
@@ -8926,9 +8926,9 @@ ms@^2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3855,16 +3855,17 @@ cozy-client@^27.14.4:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-34.2.0.tgz#d5af57b638b46dc640653e4bc603534353239632"
-  integrity sha512-t4YYXuGlrStQPEmReJm6nrrVWeKh4Jxrwuh4XSEuHCApH775wPGZZfDs1RdtYx/wCFPfI5PVM0BmvCosGju/bw==
+cozy-client@^34.5.0:
+  version "34.5.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-34.5.0.tgz#862e62d3cb545fa34a66fdc0457521bc2959cb3b"
+  integrity sha512-oqrJZTg1UtqtsPBMuk4alJP/D3A2JLh0ofzAmikmnxS/wYlsP0Dn6T4Rl6FUWU4udg7wZ+3AU9PkusIWpe4zrg==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
     cozy-stack-client "^34.1.5"
+    date-fns "2.29.3"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
     microee "^0.0.6"
@@ -4368,6 +4369,11 @@ data-urls@^2.0.0:
     abab "^2.0.3"
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
+
+date-fns@2.29.3:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
 date-fns@^1.28.5, date-fns@^1.30.1:
   version "1.30.1"


### PR DESCRIPTION
```
### 🐛 Bug Fixes

* Hide app under maintenance by default
```

This PR is a fix for the feature to have an filter to show app under maintenance. I didn't apply a filter by default to hide app under maintenance without showing into query url params.

**Related PRs:**
- https://github.com/cozy/cozy-ui/pull/2312