### PR TITLE
fix: filter take into account back

### DIFF
--- a/src/ducks/apps/components/QuerystringSections.jsx
+++ b/src/ducks/apps/components/QuerystringSections.jsx
@@ -112,4 +112,4 @@ const QuerystringSectionsWrapper = props => {
   )
 }
 
-export default React.memo(QuerystringSectionsWrapper)
+export default QuerystringSectionsWrapper


### PR DESCRIPTION
```
### 🐛 Bug Fixes

* Filter taken back into account
```

QuerystringSections render on every action on cozy-store to avoid that we put a memo on it. This creates an issue on filter update to get back to normal we remove Memo.
