### PR TITLE
fix(AppRouter.jsx): make discover the default route

### DIFF
--- a/src/ducks/components/AppRouter.jsx
+++ b/src/ducks/components/AppRouter.jsx
@@ -10,7 +10,7 @@ export const AppRouter = () => {
       <Route path="redirect" render={() => <IntentRedirect />} />
       <Route path={`discover/*`} element={<Discover />} />
       <Route path={`myapps/*`} element={<MyApplications />} />
-      <Route path="*" element={<Navigate replace to="myapps" />} />
+      <Route path="*" element={<Navigate replace to="discover" />} />
     </Routes>
   )
 }

--- a/test/components/__snapshots__/sidebar.spec.js.snap
+++ b/test/components/__snapshots__/sidebar.spec.js.snap
@@ -18,7 +18,7 @@ exports[`StoreSidebar component should be rendered correctly 1`] = `
     element={
       <Navigate
         replace={true}
-        to="myapps"
+        to="discover"
       />
     }
     path="*"
@@ -44,7 +44,7 @@ exports[`StoreSidebar component should not render if nav is disabled using searc
     element={
       <Navigate
         replace={true}
-        to="myapps"
+        to="discover"
       />
     }
     path="*"
@@ -70,7 +70,7 @@ exports[`StoreSidebar component should not render if nav is enabled but only one
     element={
       <Navigate
         replace={true}
-        to="myapps"
+        to="discover"
       />
     }
     path="*"
@@ -96,7 +96,7 @@ exports[`StoreSidebar component should not render if nav is enabled but only one
     element={
       <Navigate
         replace={true}
-        to="myapps"
+        to="discover"
       />
     }
     path="*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8939,9 +8939,9 @@ ms@^2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
```
### 🐛 Bug Fixes

* make discover the default route
```

After the refacto of react-router-v6, the default route was myapps. This fix make by default the discove as before the refacto. 