### PR TITLE
fix: Trash icon size was too small on uninstall button on some mobile screens

### DIFF
--- a/src/ducks/apps/components/UninstallModal.jsx
+++ b/src/ducks/apps/components/UninstallModal.jsx
@@ -5,8 +5,9 @@ import compose from 'lodash/flowRight'
 
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
-import Button from 'cozy-ui/transpiled/react/Button'
-import Trash from 'cozy-ui/transpiled/react/Icons/Trash'
+import Buttons from 'cozy-ui/transpiled/react/Buttons'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
 import { getAppBySlug, uninstallApp } from 'ducks/apps'
 import Modal, {
   ModalDescription,
@@ -115,22 +116,21 @@ export class UninstallModal extends Component {
             )}
           </ModalDescription>
           <ModalFooter className="sto-modal-controls">
-            <Button
-              theme="secondary"
+            <Buttons
+              variant="secondary"
               onClick={dismissAction}
               label={t('app_modal.uninstall.cancel')}
-              extension="full"
-              className="u-mh-half"
+              className="u-flex-grow-1 u-mh-half"
             />
-            <Button
-              busy={isUninstalling}
-              disabled={isUninstalling || isInstalling || !!linkedAppError}
-              theme="danger"
-              icon={Trash}
+            <Buttons
+              variant="primary"
               onClick={this.handleUninstallApp}
               label={t('app_modal.uninstall.uninstall')}
-              extension="full"
-              className="u-mh-half"
+              className="u-flex-grow-1 u-mh-half"
+              color="error"
+              startIcon={<Icon icon={TrashIcon} />}
+              busy={isUninstalling}
+              disabled={isUninstalling || isInstalling || !!linkedAppError}
             />
           </ModalFooter>
         </Modal>

--- a/test/ducks/apps/components/__snapshots__/uninstallModal.spec.js.snap
+++ b/test/ducks/apps/components/__snapshots__/uninstallModal.spec.js.snap
@@ -24,21 +24,25 @@ exports[`UninstallModal component should be rendered correctly (app uninstallabl
     <ModalFooter
       className="sto-modal-controls"
     >
-      <DefaultButton
-        className="u-mh-half"
-        extension="full"
+      <Buttons
+        className="u-flex-grow-1 u-mh-half"
         label="Cancel"
         onClick={[MockFunction]}
-        theme="secondary"
+        variant="secondary"
       />
-      <DefaultButton
-        className="u-mh-half"
+      <Buttons
+        className="u-flex-grow-1 u-mh-half"
+        color="error"
         disabled={false}
-        extension="full"
-        icon={[Function]}
         label="Uninstall"
         onClick={[Function]}
-        theme="danger"
+        startIcon={
+          <Icon
+            icon={[Function]}
+            spin={false}
+          />
+        }
+        variant="primary"
       />
     </ModalFooter>
   </Modal>
@@ -74,21 +78,25 @@ exports[`UninstallModal component should handle correctly error from props 1`] =
     <ModalFooter
       className="sto-modal-controls"
     >
-      <DefaultButton
-        className="u-mh-half"
-        extension="full"
+      <Buttons
+        className="u-flex-grow-1 u-mh-half"
         label="Cancel"
         onClick={[MockFunction]}
-        theme="secondary"
+        variant="secondary"
       />
-      <DefaultButton
-        className="u-mh-half"
+      <Buttons
+        className="u-flex-grow-1 u-mh-half"
+        color="error"
         disabled={false}
-        extension="full"
-        icon={[Function]}
         label="Uninstall"
         onClick={[Function]}
-        theme="danger"
+        startIcon={
+          <Icon
+            icon={[Function]}
+            spin={false}
+          />
+        }
+        variant="primary"
       />
     </ModalFooter>
   </Modal>
@@ -132,21 +140,25 @@ exports[`UninstallModal component should handle correctly linked app error 1`] =
     <ModalFooter
       className="sto-modal-controls"
     >
-      <DefaultButton
-        className="u-mh-half"
-        extension="full"
+      <Buttons
+        className="u-flex-grow-1 u-mh-half"
         label="Cancel"
         onClick={[MockFunction]}
-        theme="secondary"
+        variant="secondary"
       />
-      <DefaultButton
-        className="u-mh-half"
+      <Buttons
+        className="u-flex-grow-1 u-mh-half"
+        color="error"
         disabled={true}
-        extension="full"
-        icon={[Function]}
         label="Uninstall"
         onClick={[Function]}
-        theme="danger"
+        startIcon={
+          <Icon
+            icon={[Function]}
+            spin={false}
+          />
+        }
+        variant="primary"
       />
     </ModalFooter>
   </Modal>


### PR DESCRIPTION
Happened on some mobile screens like 360*568. Solved by updating to new Buttons from cozy-ui.

```
### 🐛 Bug Fixes

* Trash icon size was too small on uninstall button on some mobile
```
