### PR TITLE
Add `redirectAfterInstall` search params to be able to redirect after  installing an app/connector

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "cozy-interapp": "0.7.4",
     "cozy-logger": "1.9.0",
     "cozy-realtime": "3.14.4",
-    "cozy-ui": "^79.0.0",
+    "cozy-ui": "^79.3.0",
     "emoji-js": "3.7.0",
     "focus-trap-react": "4.0.1",
     "fuse.js": "6.5.3",

--- a/src/ducks/apps/components/ApplicationPage/Header.jsx
+++ b/src/ducks/apps/components/ApplicationPage/Header.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import { connect } from 'react-redux'
 import compose from 'lodash/flowRight'
 
@@ -32,6 +32,7 @@ export const Header = ({
   breakpoints = {},
   client
 }) => {
+  const { search } = useLocation()
   const webviewIntent = useWebviewIntent()
   const { slug, installed, type, uninstallable } = app
   const { isMobile } = breakpoints
@@ -86,7 +87,7 @@ export const Header = ({
         ) : (
           <Button
             tag={Link}
-            to={`/${parent}/${slug}/install`}
+            to={`/${parent}/${slug}/install${search}`}
             theme="primary"
             extension={isMobile ? 'full' : null}
             disabled={isInstallDisabled}
@@ -103,7 +104,7 @@ export const Header = ({
         {installed && (
           <Button
             tag={Link}
-            to={`/${parent}/${slug}/uninstall`}
+            to={`/${parent}/${slug}/uninstall${search}`}
             theme="secondary"
             extension={isMobile ? 'full' : null}
             className={isMobile ? 'u-mt-1' : null}

--- a/src/ducks/apps/components/ApplicationPage/Header.jsx
+++ b/src/ducks/apps/components/ApplicationPage/Header.jsx
@@ -14,8 +14,7 @@ import { isFlagshipApp } from 'cozy-device-helper'
 
 import cozySmileIcon from 'assets/icons/icon-cozy-smile.svg'
 import AsyncButton from 'ducks/components/AsyncButton'
-
-import { APP_TYPE, getAppIconProps } from 'ducks/apps'
+import { APP_TYPE, getAppIconProps, openApp } from 'ducks/apps'
 import {
   hasPendingUpdate,
   isUnderMaintenance,
@@ -37,13 +36,11 @@ export const Header = ({
   const { slug, installed, type, uninstallable } = app
   const { isMobile } = breakpoints
   const isCurrentAppInstalling = isInstalling === slug
-  const openApp = () => {
-    if (isFlagshipApp()) {
-      webviewIntent.call('openApp', app.related, app)
-    } else {
-      window.location.assign(app.related)
-    }
+
+  const handleClick = () => {
+    openApp(webviewIntent, app)
   }
+
   const openConnector = () => {
     if (isFlagshipApp()) {
       return webviewIntent.call('openApp', app.related, app)
@@ -54,12 +51,14 @@ export const Header = ({
       })
     }
   }
+
   const isKonnector = type === APP_TYPE.KONNECTOR
   const isInstallDisabled = !!isUnderMaintenance(app) || isInstalling
   const isUninstallDisabled = !uninstallable || isCurrentAppInstalling
   const appOrKonnectorLabel = isKonnector
     ? t('app_page.webapp.open')
     : t('app_page.konnector.open')
+
   return (
     <div className="sto-app-header">
       <div className="sto-app-header-icon">
@@ -79,7 +78,7 @@ export const Header = ({
             />
           ) : (
             <Button
-              onClick={openApp}
+              onClick={handleClick}
               className="c-btn"
               label={appOrKonnectorLabel}
             />

--- a/src/ducks/apps/components/Discover.jsx
+++ b/src/ducks/apps/components/Discover.jsx
@@ -1,6 +1,6 @@
 /* global cozy */
 import React, { Component } from 'react'
-import { useMatch } from 'react-router-dom'
+import { useMatch, useSearchParams } from 'react-router-dom'
 
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
@@ -23,7 +23,23 @@ export class Discover extends Component {
   }
 
   onAppClick(appSlug) {
-    this.props.navigate(`/discover/${appSlug}`)
+    const { navigate, searchParams } = this.props
+
+    if (searchParams) {
+      const redirectRawPath = searchParams.get('redirectAfterInstall')
+
+      if (redirectRawPath) {
+        const redirectURL = new URL(redirectRawPath)
+        redirectURL.hash += `?connectorSlug=${appSlug}`
+        const encodedRedirectPath = encodeURIComponent(redirectURL.href)
+
+        return navigate(
+          `/discover/${appSlug}?redirectAfterInstall=${encodedRedirectPath}`
+        )
+      }
+    }
+
+    navigate(`/discover/${appSlug}`)
   }
 
   pushQuery(query) {
@@ -46,6 +62,7 @@ export class Discover extends Component {
 
     const { isMobile } = breakpoints
     const title = <h2 className="sto-view-title">{t('discover.title')}</h2>
+
     return (
       <Content className="sto-discover">
         {isExact && isFetching && <AppsLoading />}
@@ -79,8 +96,16 @@ export class Discover extends Component {
 const DiscoverWrapper = props => {
   const isExact = useMatch('discover')
   const navigate = useNavigateNoUpdates()
+  const [searchParams] = useSearchParams()
 
-  return <Discover {...props} isExact={isExact} navigate={navigate} />
+  return (
+    <Discover
+      {...props}
+      isExact={isExact}
+      navigate={navigate}
+      searchParams={searchParams}
+    />
+  )
 }
 
 export default translate()(withBreakpoints()(withRouterUtils(DiscoverWrapper)))

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -1,13 +1,12 @@
 /* eslint-env browser */
 
+import CozyRealtime from 'cozy-realtime'
+import { isFlagshipApp } from 'cozy-device-helper'
+
 import config from 'config/apps'
 import storeConfig from 'config'
 import AUTHORIZED_CATEGORIES from 'config/categories'
 import { NotUninstallableAppException } from 'lib/exceptions'
-import CozyRealtime from 'cozy-realtime'
-
-export * from 'ducks/apps/selectors'
-export { appsReducers } from 'ducks/apps/reducers'
 import {
   LOADING_APP,
   LOADING_APP_INTENT,
@@ -39,6 +38,8 @@ import flatten from 'lodash/flatten'
 export { APP_STATE }
 export { APP_TYPE }
 export { REGISTRY_CHANNELS }
+export * from 'ducks/apps/selectors'
+export { appsReducers } from 'ducks/apps/reducers'
 
 const APPS_DOCTYPE = 'io.cozy.apps'
 const KONNECTORS_DOCTYPE = 'io.cozy.konnectors'
@@ -529,5 +530,13 @@ export function installAppFromRegistry(
   return dispatch => {
     const source = `registry://${app.slug}/${channel}`
     return dispatch(installApp(client, app, source, isUpdate))
+  }
+}
+
+export const openApp = (webviewIntent, app) => {
+  if (isFlagshipApp()) {
+    webviewIntent.call('openApp', app.related, app)
+  } else {
+    window.location.assign(app.related)
   }
 }

--- a/src/ducks/components/AppRouter.jsx
+++ b/src/ducks/components/AppRouter.jsx
@@ -8,8 +8,8 @@ export const AppRouter = () => {
   return (
     <Routes>
       <Route path="redirect" render={() => <IntentRedirect />} />
-      <Route path={`discover/*`} element={<Discover />} />
-      <Route path={`myapps/*`} element={<MyApplications />} />
+      <Route path="discover/*" element={<Discover />} />
+      <Route path="myapps/*" element={<MyApplications />} />
       <Route path="*" element={<Navigate replace to="discover" />} />
     </Routes>
   )

--- a/test/ducks/apps/components/applicationPage/header.spec.js
+++ b/test/ducks/apps/components/applicationPage/header.spec.js
@@ -3,7 +3,7 @@
 /* eslint-env jest */
 
 import React from 'react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, useLocation } from 'react-router-dom'
 import { render, fireEvent } from '@testing-library/react'
 import { shallow } from 'enzyme'
 
@@ -41,6 +41,11 @@ jest.mock('cozy-interapp', () => {
   })
 })
 
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: jest.fn()
+}))
+
 const AppLike = ({ children, client, webviewService }) => (
   <MemoryRouter>
     <BreakpointsProvider>
@@ -60,6 +65,7 @@ describe('ApplicationPage header component', () => {
     window.location.assign.mockReset()
     isFlagshipApp.mockReset()
     mockIntentRedirect.mockReset()
+    useLocation.mockReturnValue({ search: '' })
   })
 
   it('should be rendered correctly provided app', () => {

--- a/test/ducks/apps/components/applicationRouting/installRoute.spec.js
+++ b/test/ducks/apps/components/applicationRouting/installRoute.spec.js
@@ -4,7 +4,7 @@
 
 import React from 'react'
 import { shallow } from 'enzyme'
-import { useParams } from 'react-router-dom'
+import { useParams, useSearchParams } from 'react-router-dom'
 import { InstallRoute } from 'ducks/apps/components/ApplicationRouting/InstallRoute'
 import mockApps from '../../_mockApps'
 
@@ -18,13 +18,15 @@ const getProps = (isFetching = false, getApp = getAppMock) => ({
 })
 
 jest.mock('react-router-dom', () => ({
-  useParams: jest.fn()
+  useParams: jest.fn(),
+  useSearchParams: jest.fn()
 }))
 
 describe('InstallRoute component', () => {
   it('should display install modal if app found in the registry but not installed', () => {
     // photos in mockApps is isInRegistry
     useParams.mockReturnValue({ appSlug: 'photos' })
+    useSearchParams.mockReturnValue([{ get: jest.fn() }])
     const props = getProps()
     const component = shallow(<InstallRoute {...props} />)
     expect(component).toMatchSnapshot()
@@ -33,6 +35,7 @@ describe('InstallRoute component', () => {
   it('should display install modal if app found in the registry installed but with available version', () => {
     // tasky in mockApps is isInRegistry, installed and availableVersion
     useParams.mockReturnValue({ appSlug: 'tasky' })
+    useSearchParams.mockReturnValue([{ get: jest.fn() }])
     const props = getProps()
     const component = shallow(<InstallRoute {...props} />)
     expect(component).toMatchSnapshot()
@@ -41,6 +44,7 @@ describe('InstallRoute component', () => {
   it('should display nothing if isFetching', () => {
     // photos in mockApps is isInRegistry
     useParams.mockReturnValue({ appSlug: 'photos' })
+    useSearchParams.mockReturnValue([{ get: jest.fn() }])
     const props = getProps(true)
     const component = shallow(<InstallRoute {...props} />)
     expect(component.isEmptyRender()).toBe(true)
@@ -48,6 +52,7 @@ describe('InstallRoute component', () => {
 
   it('should redirectTo parent if no app found', () => {
     useParams.mockReturnValue({})
+    useSearchParams.mockReturnValue([{ get: jest.fn() }])
     const props = getProps(false, jest.fn())
     const component = shallow(<InstallRoute {...props} />)
     expect(props.redirectTo.mock.calls.length).toBe(1)
@@ -57,6 +62,7 @@ describe('InstallRoute component', () => {
 
   it('should redirectTo parent if app found but installed without available version', () => {
     useParams.mockReturnValue({ appSlug: 'collect' })
+    useSearchParams.mockReturnValue([{ get: jest.fn() }])
     const props = getProps(false, jest.fn())
     const component = shallow(<InstallRoute {...props} />)
     expect(props.redirectTo.mock.calls.length).toBe(1)

--- a/test/ducks/apps/components/discover.spec.js
+++ b/test/ducks/apps/components/discover.spec.js
@@ -79,8 +79,45 @@ describe('Discover component', () => {
     const instance = component.instance()
     instance.onAppClick(mockRegistyApps[0].slug)
     expect(mockProps.navigate).toHaveBeenCalledTimes(1)
+    expect(mockProps.navigate).toHaveBeenCalledWith(`/discover/collect`)
+  })
+
+  it('should define the correct onAppClick function to pass to sections with redirectAfterInstall search params, and so replace __APPSLUG__', () => {
+    const mockProps = getMockProps()
+    const component = shallow(
+      <Discover
+        t={tMock}
+        {...mockProps}
+        searchParams={{
+          get: () =>
+            'http://mespapiers.mycozy.cloud/#/paper/files/energy_invoice/harvest/'
+        }}
+      />
+    )
+    const instance = component.instance()
+    instance.onAppClick(mockRegistyApps[0].slug)
+    expect(mockProps.navigate).toHaveBeenCalledTimes(1)
     expect(mockProps.navigate).toHaveBeenCalledWith(
-      `/discover/${mockRegistyApps[0].slug}`
+      `/discover/collect?redirectAfterInstall=http%3A%2F%2Fmespapiers.mycozy.cloud%2F%23%2Fpaper%2Ffiles%2Fenergy_invoice%2Fharvest%2F%3FconnectorSlug%3Dcollect`
+    )
+  })
+
+  it('should encode uri when using redirectAfterInstall search params', () => {
+    const mockProps = getMockProps()
+    const component = shallow(
+      <Discover
+        t={tMock}
+        {...mockProps}
+        searchParams={{
+          get: () => 'http://mydomain/#/paper?param1=val1&param2=val2'
+        }}
+      />
+    )
+    const instance = component.instance()
+    instance.onAppClick(mockRegistyApps[0].slug)
+    expect(mockProps.navigate).toHaveBeenCalledTimes(1)
+    expect(mockProps.navigate).toHaveBeenCalledWith(
+      `/discover/collect?redirectAfterInstall=http%3A%2F%2Fmydomain%2F%23%2Fpaper%3Fparam1%3Dval1%26param2%3Dval2%3FconnectorSlug%3Dcollect`
     )
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4097,10 +4097,10 @@ cozy-ui@22.3.1:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
-cozy-ui@^79.0.0:
-  version "79.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-79.0.0.tgz#1e3a0c22e3c8a0f16900bb3013787414b7a98e69"
-  integrity sha512-89cjOTqdEzqR51F8bawyYmWbB+Pvnc/WavxbkiRni8rxLRnj36FLTTXLuENiib+bAZf9HulZFnrNfB5cZMKTEw==
+cozy-ui@^79.3.0:
+  version "79.3.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-79.3.0.tgz#9915a3f1aab474b00dc4033d907a31fabb2d1c08"
+  integrity sha512-OR9KZF9i+alc2sWC7gG2lNuBqiIjJnxkctwt44mK1jWHpQWrQ/4d4HhOcwAcDoAkIWiQyLvmiZivfZVZ3fL/QQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"
@@ -8939,9 +8939,9 @@ ms@^2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
Le besoin actuel est que depuis MesPapiers on souhaite installer un connecteur, 
et revenir dans l'application après installation du connecteur. Pour se faire 
on compute depuis l'app la route à retourner, et on la passe à Store depuis 
l'url et le search param `redirectAfterInstall`.


```
### ✨ Features

* Add `redirectAfterInstall` search param support
* Keep search params when (un)installing an app/connector
* Upgrade cozy-ui from 79.0.0 to 79.3.0

### 🔧 Tech

* Extract openApp func from Header
```