### PR TITLE
fix: My apps show maintenance apps by default

### DIFF
--- a/src/ducks/apps/components/QuerystringSections.jsx
+++ b/src/ducks/apps/components/QuerystringSections.jsx
@@ -66,7 +66,10 @@ const QuerystringSections = props => {
   const { pathname, search } = useLocationNoUpdates()
 
   // Restores the search from the URL querypart
-  const filter = useMemo(() => getFilterFromQuery(search, parent), [search])
+  const filter = useMemo(() => getFilterFromQuery(search, props.parent), [
+    props.parent,
+    search
+  ])
 
   // Saves filter to query part
   const handleFilterChange = filter => {


### PR DESCRIPTION
Using the wrong parent variable as ti was window.parent instead of component props

```
### 🐛 Bug Fixes

* My apps page show all apps by default
```
