### PR TITLE
Add AA and Pass mobile push banners

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -80,8 +80,12 @@
       ]
     },
     "settings": {
-      "description": "Required by the cozy-bar to display Claudy and know which applications are coming soon",
-      "type": "io.cozy.settings",
+      "description": "Required by the push banners and the cozy-bar to display Claudy and know which applications are coming soon",
+      "type": "io.cozy.settings"
+    },
+    "oAuthClients": {
+      "description": "Required by the push banners",
+      "type": "io.cozy.oauth.clients",
       "verbs": [
         "GET"
       ]

--- a/src/ducks/components/App.jsx
+++ b/src/ducks/components/App.jsx
@@ -12,7 +12,7 @@ import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoin
 
 import { initApp, restoreAppIfSaved } from 'ducks/apps'
 import { AppRouter } from 'ducks/components/AppRouter'
-import PushBanners from 'ducks/components/PushBanners'
+import PushBannersLoader from 'ducks/components/PushBanners'
 import Sidebar from 'ducks/components/Sidebar'
 
 export class App extends Component {
@@ -29,7 +29,7 @@ export class App extends Component {
           <Alerter />
           <Sidebar />
           <Main>
-            {!flag('cozy.pushbanners.hide') && <PushBanners />}
+            {!flag('cozy.pushbanners.hide') && <PushBannersLoader />}
             <AppRouter />
           </Main>
           <IconSprite />

--- a/src/ducks/components/App.jsx
+++ b/src/ducks/components/App.jsx
@@ -1,21 +1,19 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
+import compose from 'lodash/flowRight'
 
-import { translate } from 'cozy-ui/transpiled/react/I18n'
 import flag, { FlagSwitcher } from 'cozy-flags'
-
-import { AppRouter } from 'ducks/components/AppRouter'
-import Sidebar from 'ducks/components/Sidebar'
-
-import { initApp, restoreAppIfSaved } from 'ducks/apps'
-
+import { withClient } from 'cozy-client'
+import { translate } from 'cozy-ui/transpiled/react/I18n'
 import { Layout, Main } from 'cozy-ui/transpiled/react/Layout'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import IconSprite from 'cozy-ui/transpiled/react/Icon/Sprite'
 import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
-import compose from 'lodash/flowRight'
-import { withClient } from 'cozy-client'
+import { initApp, restoreAppIfSaved } from 'ducks/apps'
+import { AppRouter } from 'ducks/components/AppRouter'
+import PushBanners from 'ducks/components/PushBanners'
+import Sidebar from 'ducks/components/Sidebar'
 
 export class App extends Component {
   constructor(props) {
@@ -31,6 +29,7 @@ export class App extends Component {
           <Alerter />
           <Sidebar />
           <Main>
+            {!flag('cozy.pushbanners.hide') && <PushBanners />}
             <AppRouter />
           </Main>
           <IconSprite />

--- a/src/ducks/components/PushBanners/BannerForAA.jsx
+++ b/src/ducks/components/PushBanners/BannerForAA.jsx
@@ -1,0 +1,58 @@
+import React from 'react'
+
+import { useClient } from 'cozy-client'
+import { isMobile, isIOS } from 'cozy-device-helper'
+import Banner from 'cozy-ui/transpiled/react/Banner'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import Button from 'cozy-ui/transpiled/react/Buttons'
+import DevicePhoneIcon from 'cozy-ui/transpiled/react/Icons/DevicePhone'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
+const BannerForAA = ({ setting, setHasDismissedAABanner }) => {
+  const { t, lang } = useI18n()
+  const client = useClient()
+
+  const downloadLink = !isMobile()
+    ? `https://cozy.io/${lang}/download`
+    : isIOS()
+    ? `https://apps.apple.com/${lang}/app/my-cozy/id1600636174`
+    : `https://play.google.com/store/apps/details?id=io.cozy.flagship.mobile&hl=${lang}`
+
+  const handleClick = () => {
+    setHasDismissedAABanner(true)
+    client.save({
+      ...setting,
+      _id: 'io.cozy.settings.display',
+      _type: 'io.cozy.settings',
+      pushBanners: { ...setting.pushBanners, hideAA: true }
+    })
+  }
+
+  return (
+    <Banner
+      icon={<Icon icon={DevicePhoneIcon} />}
+      text={t('pushBanners.text.AA')}
+      bgcolor="var(--defaultBackgroundColor)"
+      inline
+      buttonOne={
+        <Button
+          className="u-mr-1"
+          variant="text"
+          component="a"
+          href={downloadLink}
+          target="_blank"
+          label={t('pushBanners.download')}
+        />
+      }
+      buttonTwo={
+        <Button
+          variant="text"
+          label={t('pushBanners.no-thanks')}
+          onClick={handleClick}
+        />
+      }
+    />
+  )
+}
+
+export default BannerForAA

--- a/src/ducks/components/PushBanners/BannerForFlagshipApp.jsx
+++ b/src/ducks/components/PushBanners/BannerForFlagshipApp.jsx
@@ -8,7 +8,10 @@ import Button from 'cozy-ui/transpiled/react/Buttons'
 import DevicePhoneIcon from 'cozy-ui/transpiled/react/Icons/DevicePhone'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
-const BannerForAA = ({ setting, setHasDismissedAABanner }) => {
+const BannerForFlagshipApp = ({
+  setting,
+  setHasDismissedFlagshipAppBanner
+}) => {
   const { t, lang } = useI18n()
   const client = useClient()
 
@@ -19,19 +22,19 @@ const BannerForAA = ({ setting, setHasDismissedAABanner }) => {
     : `https://play.google.com/store/apps/details?id=io.cozy.flagship.mobile&hl=${lang}`
 
   const handleClick = () => {
-    setHasDismissedAABanner(true)
+    setHasDismissedFlagshipAppBanner(true)
     client.save({
       ...setting,
       _id: 'io.cozy.settings.display',
       _type: 'io.cozy.settings',
-      pushBanners: { ...setting.pushBanners, hideAA: true }
+      pushBanners: { ...setting.pushBanners, hideFlagshipApp: true }
     })
   }
 
   return (
     <Banner
       icon={<Icon icon={DevicePhoneIcon} />}
-      text={t('pushBanners.text.AA')}
+      text={t('pushBanners.text.flagshipApp')}
       bgcolor="var(--defaultBackgroundColor)"
       inline
       buttonOne={
@@ -55,4 +58,4 @@ const BannerForAA = ({ setting, setHasDismissedAABanner }) => {
   )
 }
 
-export default BannerForAA
+export default BannerForFlagshipApp

--- a/src/ducks/components/PushBanners/BannerForPass.jsx
+++ b/src/ducks/components/PushBanners/BannerForPass.jsx
@@ -1,0 +1,57 @@
+import React from 'react'
+
+import { useClient } from 'cozy-client'
+import { isMobile, isIOS } from 'cozy-device-helper'
+import Banner from 'cozy-ui/transpiled/react/Banner'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import Button from 'cozy-ui/transpiled/react/Buttons'
+import DevicePhoneIcon from 'cozy-ui/transpiled/react/Icons/DevicePhone'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
+const BannerForPass = ({ setting }) => {
+  const { t, lang } = useI18n()
+  const client = useClient()
+
+  const downloadLink = !isMobile()
+    ? `https://cozy.io/${lang}/download`
+    : isIOS()
+    ? `https://apps.apple.com/${lang}/app/cozy-pass/id1502262449`
+    : `https://play.google.com/store/apps/details?id=io.cozy.pass&hl=${lang}`
+
+  const handleClick = () => {
+    client.save({
+      ...setting,
+      _id: 'io.cozy.settings.display',
+      _type: 'io.cozy.settings',
+      pushBanners: { ...setting.pushBanners, hidePassMobile: true }
+    })
+  }
+
+  return (
+    <Banner
+      icon={<Icon icon={DevicePhoneIcon} />}
+      text={t('pushBanners.text.pass')}
+      bgcolor="var(--defaultBackgroundColor)"
+      inline
+      buttonOne={
+        <Button
+          className="u-mr-1"
+          variant="text"
+          component="a"
+          href={downloadLink}
+          target="_blank"
+          label={t('pushBanners.download')}
+        />
+      }
+      buttonTwo={
+        <Button
+          variant="text"
+          label={t('pushBanners.no-thanks')}
+          onClick={handleClick}
+        />
+      }
+    />
+  )
+}
+
+export default BannerForPass

--- a/src/ducks/components/PushBanners/PushBanners.jsx
+++ b/src/ducks/components/PushBanners/PushBanners.jsx
@@ -1,0 +1,45 @@
+import React, { useState, useEffect, useRef } from 'react'
+import { useLocation } from 'react-router-dom'
+
+import { makePushBanner } from './helpers'
+
+const PushBanners = ({ oAuthClients, setting }) => {
+  const { hash, pathname, search } = useLocation()
+  const path = hash + pathname + search
+  const prevPath = useRef(path)
+  const [hasDismissedAABanner, setHasDismissedAABanner] = useState(false)
+  const [showBanner, setShowBanner] = useState(true)
+
+  const PushBanner = makePushBanner(oAuthClients, setting)
+
+  // We don't want to display the pass banner immediately
+  // after dismissed the AA banner, but only after a url change.
+  useEffect(() => {
+    if (hasDismissedAABanner) {
+      if (path === prevPath.current) {
+        setShowBanner(false)
+      } else {
+        setShowBanner(true)
+      }
+    }
+
+    prevPath.current = path
+  }, [hasDismissedAABanner, path])
+
+  if (showBanner && PushBanner) {
+    return (
+      <PushBanner
+        setting={setting}
+        setHasDismissedAABanner={setHasDismissedAABanner}
+      />
+    )
+  }
+
+  return null
+}
+
+PushBanners.defaultProps = {
+  setting: {}
+}
+
+export default PushBanners

--- a/src/ducks/components/PushBanners/PushBanners.jsx
+++ b/src/ducks/components/PushBanners/PushBanners.jsx
@@ -7,15 +7,18 @@ const PushBanners = ({ oAuthClients, setting }) => {
   const { hash, pathname, search } = useLocation()
   const path = hash + pathname + search
   const prevPath = useRef(path)
-  const [hasDismissedAABanner, setHasDismissedAABanner] = useState(false)
+  const [
+    hasDismissedFlagshipAppBanner,
+    setHasDismissedFlagshipAppBanner
+  ] = useState(false)
   const [showBanner, setShowBanner] = useState(true)
 
   const PushBanner = makePushBanner(oAuthClients, setting)
 
   // We don't want to display the pass banner immediately
-  // after dismissed the AA banner, but only after a url change.
+  // after dismissed the FlagshipApp banner, but only after a url change.
   useEffect(() => {
-    if (hasDismissedAABanner) {
+    if (hasDismissedFlagshipAppBanner) {
       if (path === prevPath.current) {
         setShowBanner(false)
       } else {
@@ -24,13 +27,13 @@ const PushBanners = ({ oAuthClients, setting }) => {
     }
 
     prevPath.current = path
-  }, [hasDismissedAABanner, path])
+  }, [hasDismissedFlagshipAppBanner, path])
 
   if (showBanner && PushBanner) {
     return (
       <PushBanner
         setting={setting}
-        setHasDismissedAABanner={setHasDismissedAABanner}
+        setHasDismissedFlagshipAppBanner={setHasDismissedFlagshipAppBanner}
       />
     )
   }

--- a/src/ducks/components/PushBanners/helpers.js
+++ b/src/ducks/components/PushBanners/helpers.js
@@ -2,18 +2,11 @@ import BannerForAA from './BannerForAA'
 import BannerForPass from './BannerForPass'
 
 export const makePushBanner = (oAuthClients, setting) => {
-  const { hasAAClient, hasPassClient } = oAuthClients.reduce(
-    (acc, curr) => {
-      if (curr.software_id === 'io.cozy.pass.mobile') {
-        acc.hasPassClient = true
-      }
-      if (curr.software_id === 'amiral') {
-        acc.hasAAClient = true
-      }
-
-      return acc
-    },
-    { hasAAClient: false, hasPassClient: false }
+  const hasAAClient = oAuthClients.some(
+    oAuthClient => oAuthClient.software_id === 'amiral'
+  )
+  const hasPassClient = oAuthClients.some(
+    oAuthClient => oAuthClient.software_id === 'io.cozy.pass.mobile'
   )
 
   const { hideAA = false, hidePassMobile = false } = setting.pushBanners || {
@@ -21,17 +14,12 @@ export const makePushBanner = (oAuthClients, setting) => {
     hidePassMobile: false
   }
 
-  if (!hasAAClient) {
-    if (!hideAA) {
-      return BannerForAA
-    }
-    if (!hidePassMobile) {
-      return BannerForPass
-    }
-  } else {
-    if (!hasPassClient && !hidePassMobile) {
-      return BannerForPass
-    }
+  if (!hasAAClient && !hideAA) {
+    return BannerForAA
+  }
+
+  if (!hasPassClient && !hidePassMobile) {
+    return BannerForPass
   }
 
   return null

--- a/src/ducks/components/PushBanners/helpers.js
+++ b/src/ducks/components/PushBanners/helpers.js
@@ -1,21 +1,24 @@
-import BannerForAA from './BannerForAA'
+import BannerForFlagshipApp from './BannerForFlagshipApp'
 import BannerForPass from './BannerForPass'
 
 export const makePushBanner = (oAuthClients, setting) => {
-  const hasAAClient = oAuthClients.some(
+  const hasFlagshipAppClient = oAuthClients.some(
     oAuthClient => oAuthClient.software_id === 'amiral'
   )
   const hasPassClient = oAuthClients.some(
     oAuthClient => oAuthClient.software_id === 'io.cozy.pass.mobile'
   )
 
-  const { hideAA = false, hidePassMobile = false } = setting.pushBanners || {
-    hideAA: false,
+  const {
+    hideFlagshipApp = false,
+    hidePassMobile = false
+  } = setting.pushBanners || {
+    hideFlagshipApp: false,
     hidePassMobile: false
   }
 
-  if (!hasAAClient && !hideAA) {
-    return BannerForAA
+  if (!hasFlagshipAppClient && !hideFlagshipApp) {
+    return BannerForFlagshipApp
   }
 
   if (!hasPassClient && !hidePassMobile) {

--- a/src/ducks/components/PushBanners/helpers.js
+++ b/src/ducks/components/PushBanners/helpers.js
@@ -1,0 +1,38 @@
+import BannerForAA from './BannerForAA'
+import BannerForPass from './BannerForPass'
+
+export const makePushBanner = (oAuthClients, setting) => {
+  const { hasAAClient, hasPassClient } = oAuthClients.reduce(
+    (acc, curr) => {
+      if (curr.software_id === 'io.cozy.pass.mobile') {
+        acc.hasPassClient = true
+      }
+      if (curr.software_id === 'amiral') {
+        acc.hasAAClient = true
+      }
+
+      return acc
+    },
+    { hasAAClient: false, hasPassClient: false }
+  )
+
+  const { hideAA = false, hidePassMobile = false } = setting.pushBanners || {
+    hideAA: false,
+    hidePassMobile: false
+  }
+
+  if (!hasAAClient) {
+    if (!hideAA) {
+      return BannerForAA
+    }
+    if (!hidePassMobile) {
+      return BannerForPass
+    }
+  } else {
+    if (!hasPassClient && !hidePassMobile) {
+      return BannerForPass
+    }
+  }
+
+  return null
+}

--- a/src/ducks/components/PushBanners/helpers.spec.js
+++ b/src/ducks/components/PushBanners/helpers.spec.js
@@ -1,50 +1,50 @@
 import { makePushBanner } from './helpers'
 
-jest.mock('./BannerForAA', () => 'BannerForAA')
+jest.mock('./BannerForFlagshipApp', () => 'BannerForFlagshipApp')
 jest.mock('./BannerForPass', () => 'BannerForPass')
 
 describe('makePushBanner', () => {
-  describe('should return the banner for AA', () => {
-    it('when no oAuth client installed for AA and Pass mobile and switches not set in database', () => {
+  describe('should return the banner for FlagshipApp', () => {
+    it('when no oAuth client installed for FlagshipApp and Pass mobile and switches not set in database', () => {
       const res = makePushBanner([{ software_id: 'other_client' }], {})
 
-      expect(res).toBe('BannerForAA')
+      expect(res).toBe('BannerForFlagshipApp')
     })
 
-    it('when no oAuth client installed for AA and Pass mobile and AA banner not dismissed', () => {
+    it('when no oAuth client installed for FlagshipApp and Pass mobile and FlagshipApp banner not dismissed', () => {
       const res = makePushBanner([{ software_id: 'other_client' }], {
         pushBanners: {
-          hideAA: false,
+          hideFlagshipApp: false,
           hidePassMobile: false
         }
       })
 
-      expect(res).toBe('BannerForAA')
+      expect(res).toBe('BannerForFlagshipApp')
     })
 
-    it('when no oAuth client installed for AA even if there is one for Pass mobile', () => {
+    it('when no oAuth client installed for FlagshipApp even if there is one for Pass mobile', () => {
       const res = makePushBanner([{ software_id: 'io.cozy.pass.mobile' }], {
         pushBanners: {
-          hideAA: false,
+          hideFlagshipApp: false,
           hidePassMobile: false
         }
       })
 
-      expect(res).toBe('BannerForAA')
+      expect(res).toBe('BannerForFlagshipApp')
     })
   })
 
   describe('should return the banner for Pass', () => {
-    it('when oAuth client installed for AA but not for Pass mobile and switches not set in database', () => {
+    it('when oAuth client installed for FlagshipApp but not for Pass mobile and switches not set in database', () => {
       const res = makePushBanner([{ software_id: 'amiral' }], {})
 
       expect(res).toBe('BannerForPass')
     })
 
-    it('when oAuth client installed for AA but not for Pass mobile', () => {
+    it('when oAuth client installed for FlagshipApp but not for Pass mobile', () => {
       const res = makePushBanner([{ software_id: 'amiral' }], {
         pushBanners: {
-          hideAA: false,
+          hideFlagshipApp: false,
           hidePassMobile: false
         }
       })
@@ -52,10 +52,10 @@ describe('makePushBanner', () => {
       expect(res).toBe('BannerForPass')
     })
 
-    it('when no oAuth client installed for AA but AA banner already dismissed', () => {
+    it('when no oAuth client installed for FlagshipApp but FlagshipApp banner already dismissed', () => {
       const res = makePushBanner([{ software_id: 'other_client' }], {
         pushBanners: {
-          hideAA: true,
+          hideFlagshipApp: true,
           hidePassMobile: false
         }
       })
@@ -65,12 +65,12 @@ describe('makePushBanner', () => {
   })
 
   describe('should return no banner', () => {
-    it('when oAuth client installed for AA and Pass', () => {
+    it('when oAuth client installed for FlagshipApp and Pass', () => {
       const res = makePushBanner(
         [{ software_id: 'amiral' }, { software_id: 'io.cozy.pass.mobile' }],
         {
           pushBanners: {
-            hideAA: false,
+            hideFlagshipApp: false,
             hidePassMobile: false
           }
         }
@@ -79,10 +79,10 @@ describe('makePushBanner', () => {
       expect(res).toBeNull()
     })
 
-    it('when oAuth client installed for AA but Pass banner already dismissed', () => {
+    it('when oAuth client installed for FlagshipApp but Pass banner already dismissed', () => {
       const res = makePushBanner([{ software_id: 'amiral' }], {
         pushBanners: {
-          hideAA: false,
+          hideFlagshipApp: false,
           hidePassMobile: true
         }
       })
@@ -90,10 +90,10 @@ describe('makePushBanner', () => {
       expect(res).toBeNull()
     })
 
-    it('when oAuth client installed for Pass and AA banner already dismissed', () => {
+    it('when oAuth client installed for Pass and FlagshipApp banner already dismissed', () => {
       const res = makePushBanner([{ software_id: 'io.cozy.pass.mobile' }], {
         pushBanners: {
-          hideAA: true,
+          hideFlagshipApp: true,
           hidePassMobile: false
         }
       })
@@ -101,10 +101,10 @@ describe('makePushBanner', () => {
       expect(res).toBeNull()
     })
 
-    it('when no oAuth client installed for AA but AA banner and Pass banner already dismissed', () => {
+    it('when no oAuth client installed for FlagshipApp but FlagshipApp banner and Pass banner already dismissed', () => {
       const res = makePushBanner([{ software_id: 'other_client' }], {
         pushBanners: {
-          hideAA: true,
+          hideFlagshipApp: true,
           hidePassMobile: true
         }
       })

--- a/src/ducks/components/PushBanners/helpers.spec.js
+++ b/src/ducks/components/PushBanners/helpers.spec.js
@@ -52,7 +52,7 @@ describe('makePushBanner', () => {
       expect(res).toBe('BannerForPass')
     })
 
-    it('when no oAuth client installed for AA but banner already dismissed', () => {
+    it('when no oAuth client installed for AA but AA banner already dismissed', () => {
       const res = makePushBanner([{ software_id: 'other_client' }], {
         pushBanners: {
           hideAA: true,
@@ -84,6 +84,17 @@ describe('makePushBanner', () => {
         pushBanners: {
           hideAA: false,
           hidePassMobile: true
+        }
+      })
+
+      expect(res).toBeNull()
+    })
+
+    it('when oAuth client installed for Pass and AA banner already dismissed', () => {
+      const res = makePushBanner([{ software_id: 'io.cozy.pass.mobile' }], {
+        pushBanners: {
+          hideAA: true,
+          hidePassMobile: false
         }
       })
 

--- a/src/ducks/components/PushBanners/helpers.spec.js
+++ b/src/ducks/components/PushBanners/helpers.spec.js
@@ -1,0 +1,104 @@
+import { makePushBanner } from './helpers'
+
+jest.mock('./BannerForAA', () => 'BannerForAA')
+jest.mock('./BannerForPass', () => 'BannerForPass')
+
+describe('makePushBanner', () => {
+  describe('should return the banner for AA', () => {
+    it('when no oAuth client installed for AA and Pass mobile and switches not set in database', () => {
+      const res = makePushBanner([{ software_id: 'other_client' }], {})
+
+      expect(res).toBe('BannerForAA')
+    })
+
+    it('when no oAuth client installed for AA and Pass mobile and AA banner not dismissed', () => {
+      const res = makePushBanner([{ software_id: 'other_client' }], {
+        pushBanners: {
+          hideAA: false,
+          hidePassMobile: false
+        }
+      })
+
+      expect(res).toBe('BannerForAA')
+    })
+
+    it('when no oAuth client installed for AA even if there is one for Pass mobile', () => {
+      const res = makePushBanner([{ software_id: 'io.cozy.pass.mobile' }], {
+        pushBanners: {
+          hideAA: false,
+          hidePassMobile: false
+        }
+      })
+
+      expect(res).toBe('BannerForAA')
+    })
+  })
+
+  describe('should return the banner for Pass', () => {
+    it('when oAuth client installed for AA but not for Pass mobile and switches not set in database', () => {
+      const res = makePushBanner([{ software_id: 'amiral' }], {})
+
+      expect(res).toBe('BannerForPass')
+    })
+
+    it('when oAuth client installed for AA but not for Pass mobile', () => {
+      const res = makePushBanner([{ software_id: 'amiral' }], {
+        pushBanners: {
+          hideAA: false,
+          hidePassMobile: false
+        }
+      })
+
+      expect(res).toBe('BannerForPass')
+    })
+
+    it('when no oAuth client installed for AA but banner already dismissed', () => {
+      const res = makePushBanner([{ software_id: 'other_client' }], {
+        pushBanners: {
+          hideAA: true,
+          hidePassMobile: false
+        }
+      })
+
+      expect(res).toBe('BannerForPass')
+    })
+  })
+
+  describe('should return no banner', () => {
+    it('when oAuth client installed for AA and Pass', () => {
+      const res = makePushBanner(
+        [{ software_id: 'amiral' }, { software_id: 'io.cozy.pass.mobile' }],
+        {
+          pushBanners: {
+            hideAA: false,
+            hidePassMobile: false
+          }
+        }
+      )
+
+      expect(res).toBeNull()
+    })
+
+    it('when oAuth client installed for AA but Pass banner already dismissed', () => {
+      const res = makePushBanner([{ software_id: 'amiral' }], {
+        pushBanners: {
+          hideAA: false,
+          hidePassMobile: true
+        }
+      })
+
+      expect(res).toBeNull()
+    })
+
+    it('when no oAuth client installed for AA but AA banner and Pass banner already dismissed', () => {
+      const res = makePushBanner([{ software_id: 'other_client' }], {
+        pushBanners: {
+          hideAA: true,
+          hidePassMobile: true
+        }
+      })
+
+      expect(res).toBeNull()
+    })
+  })
+})

--- a/src/ducks/components/PushBanners/index.jsx
+++ b/src/ducks/components/PushBanners/index.jsx
@@ -1,0 +1,42 @@
+import React from 'react'
+
+import {
+  useQueryAll,
+  useQuery,
+  isQueryLoading,
+  hasQueryBeenLoaded
+} from 'cozy-client'
+import {
+  buildOauthClientsQuery,
+  buildDisplaySettingsQuery
+} from '../../queries'
+import PushBanners from './PushBanners'
+
+const PushBannersLoader = () => {
+  const oAuthClientsQuery = buildOauthClientsQuery()
+  const { data: oAuthClients, ...oAuthClientsQueryResult } = useQueryAll(
+    oAuthClientsQuery.definition,
+    oAuthClientsQuery.options
+  )
+
+  const isOauthClientsQueryLoading =
+    isQueryLoading(oAuthClientsQueryResult) || oAuthClientsQueryResult.hasMore
+
+  const displaySettingsQuery = buildDisplaySettingsQuery()
+  const { data: displaySettings, ...displaySettingsQueryResult } = useQuery(
+    displaySettingsQuery.definition,
+    displaySettingsQuery.options
+  )
+
+  const isDisplaySettingsQueryLoading =
+    isQueryLoading(displaySettingsQueryResult) &&
+    !hasQueryBeenLoaded(displaySettingsQueryResult)
+
+  if (isOauthClientsQueryLoading || isDisplaySettingsQueryLoading) return null
+
+  return (
+    <PushBanners oAuthClients={oAuthClients} setting={displaySettings[0]} />
+  )
+}
+
+export default PushBannersLoader

--- a/src/ducks/queries.js
+++ b/src/ducks/queries.js
@@ -1,0 +1,21 @@
+import CozyClient, { Q } from 'cozy-client'
+
+const older30s = 30 * 1000
+
+export const buildOauthClientsQuery = () => ({
+  definition: Q('io.cozy.oauth.clients'),
+  options: {
+    as: 'io.cozy.oauth.clients',
+    fetchPolicy: CozyClient.fetchPolicies.olderThan(older30s)
+  }
+})
+
+export const buildDisplaySettingsQuery = () => ({
+  definition: Q('io.cozy.settings')
+    .where({ _id: 'io.cozy.settings.display' })
+    .indexFields(['_id']),
+  options: {
+    as: 'io.cozy.settings.display',
+    fetchPolicy: CozyClient.fetchPolicies.olderThan(older30s)
+  }
+})

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -312,5 +312,14 @@
   "discover-search-field": {
     "label": "Suche:",
     "placeholder": "\"CAF\", \"telecom\", \"bills\""
+  },
+
+  "pushBanners": {
+    "download": "Herunterladen",
+    "no-thanks": "Nein danke!",
+    "text": {
+      "AA": "Nehmen Sie Ihre persönliche Cloud mit: Installieren Sie unsere Cozy-App!",
+      "pass": "Ihre Passwörter sicher in Ihrer Tasche: Laden Sie Cozy Pass auf Ihr Handy herunter"
+    }
   }
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -318,7 +318,7 @@
     "download": "Herunterladen",
     "no-thanks": "Nein danke!",
     "text": {
-      "AA": "Nehmen Sie Ihre persönliche Cloud mit: Installieren Sie unsere Cozy-App!",
+      "flagshipApp": "Nehmen Sie Ihre persönliche Cloud mit: Installieren Sie unsere Cozy-App!",
       "pass": "Ihre Passwörter sicher in Ihrer Tasche: Laden Sie Cozy Pass auf Ihr Handy herunter"
     }
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -326,7 +326,7 @@
     "download": "Download",
     "no-thanks": "No thanks!",
     "text": {
-      "AA": "Take your personnal cloud with you: install Cozy on all your devices!",
+      "flagshipApp": "Take your personnal cloud with you: install Cozy on all your devices!",
       "pass": "Your passwords vault in your pocket at all time: download Cozy Pass on your mobile"
     }
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -320,5 +320,14 @@
   "discover-search-field": {
     "label": "Search:",
     "placeholder": "\"CAF\", \"telecom\", \"bills\""
+  },
+
+  "pushBanners": {
+    "download": "Download",
+    "no-thanks": "No thanks!",
+    "text": {
+      "AA": "Take your personnal cloud with you: install Cozy on all your devices!",
+      "pass": "Your passwords vault in your pocket at all time: download Cozy Pass on your mobile"
+    }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -324,7 +324,7 @@
     "download": "Télécharger",
     "no-thanks": "Non merci !",
     "text": {
-      "AA": "Emportez votre cloud personnel avec vous : installer notre app Cozy !",
+      "flagshipApp": "Emportez votre cloud personnel avec vous : installer notre app Cozy !",
       "pass": "Vos mots de passe en sécurité dans votre poche : téléchargez Cozy Pass sur votre mobile"
     }
   }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -318,5 +318,14 @@
   "discover-search-field": {
     "label": "Rechercher :",
     "placeholder": "\"CAF\", \"énergie\", \"factures\""
+  },
+
+  "pushBanners": {
+    "download": "Télécharger",
+    "no-thanks": "Non merci !",
+    "text": {
+      "AA": "Emportez votre cloud personnel avec vous : installer notre app Cozy !",
+      "pass": "Vos mots de passe en sécurité dans votre poche : téléchargez Cozy Pass sur votre mobile"
+    }
   }
 }

--- a/src/locales/nl_NL.json
+++ b/src/locales/nl_NL.json
@@ -312,5 +312,14 @@
   "discover-search-field": {
     "label": "Zoeken:",
     "placeholder": "\"NS, \"telecom\", \"rekeningen\""
+  },
+
+  "pushBanners": {
+    "download": "Downloaden",
+    "no-thanks": "Nee, dank je!",
+    "text": {
+      "AA": "Neem je persoonlijke cloud met je mee: installeer onze Cozy app!",
+      "pass": "Uw wachtwoorden veilig op zak: download Cozy Pass naar uw mobiele telefoon"
+    }
   }
 }

--- a/src/locales/nl_NL.json
+++ b/src/locales/nl_NL.json
@@ -318,7 +318,7 @@
     "download": "Downloaden",
     "no-thanks": "Nee, dank je!",
     "text": {
-      "AA": "Neem je persoonlijke cloud met je mee: installeer onze Cozy app!",
+      "flagshipApp": "Neem je persoonlijke cloud met je mee: installeer onze Cozy app!",
       "pass": "Uw wachtwoorden veilig op zak: download Cozy Pass naar uw mobiele telefoon"
     }
   }

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -292,7 +292,7 @@
     "download": "Pobierz",
     "no-thanks": "Nie, dziękuję!",
     "text": {
-      "AA": "Zabierz swoją osobistą chmurę ze sobą: zainstaluj naszą aplikację Cozy!",
+      "flagshipApp": "Zabierz swoją osobistą chmurę ze sobą: zainstaluj naszą aplikację Cozy!",
       "pass": "Bezpieczne hasła w kieszeni: pobierz Cozy Pass na swój telefon komórkowy"
     }
   }

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -286,5 +286,14 @@
       "external": "%{name} commits to giving only the following data:",
       "nothing": "%{appName} doesn't require any data access to work correctly on your Cozy."
     }
+  },
+
+  "pushBanners": {
+    "download": "Pobierz",
+    "no-thanks": "Nie, dziękuję!",
+    "text": {
+      "AA": "Zabierz swoją osobistą chmurę ze sobą: zainstaluj naszą aplikację Cozy!",
+      "pass": "Bezpieczne hasła w kieszeni: pobierz Cozy Pass na swój telefon komórkowy"
+    }
   }
 }

--- a/test/__snapshots__/app.spec.js.snap
+++ b/test/__snapshots__/app.spec.js.snap
@@ -10,6 +10,7 @@ exports[`App component only should be mounted correctly 1`] = `
     />
     <withI18n(withBreakpoints(Sidebar)) />
     <Main>
+      <PushBannersLoader />
       <AppRouter />
     </Main>
     <Sprite />


### PR DESCRIPTION
Selon une certaine logique, nous ajoutons 2 bannière push pour proposer l'app amirale et cozy pass mobile.

Après merge de cette PR, il faudra mettre à jour la doc de cozy concernant `io.settings.display` et le nouveau flag.


```
### ✨ Features

* Add AA and Pass mobile push banners

```