### PR TITLE
fix(PushBanners): Pass mobile wasn't detected correctly

### DIFF
--- a/src/ducks/components/PushBanners/BannerForFlagshipApp.jsx
+++ b/src/ducks/components/PushBanners/BannerForFlagshipApp.jsx
@@ -18,7 +18,7 @@ const BannerForFlagshipApp = ({
   const downloadLink = !isMobile()
     ? `https://cozy.io/${lang}/download`
     : isIOS()
-    ? `https://apps.apple.com/${lang}/app/my-cozy/id1600636174`
+    ? `https://apps.apple.com/${lang}/app/id1600636174`
     : `https://play.google.com/store/apps/details?id=io.cozy.flagship.mobile&hl=${lang}`
 
   const handleClick = () => {

--- a/src/ducks/components/PushBanners/helpers.js
+++ b/src/ducks/components/PushBanners/helpers.js
@@ -6,7 +6,7 @@ export const makePushBanner = (oAuthClients, setting) => {
     oAuthClient => oAuthClient.software_id === 'amiral'
   )
   const hasPassClient = oAuthClients.some(
-    oAuthClient => oAuthClient.software_id === 'io.cozy.pass.mobile'
+    oAuthClient => oAuthClient.software_id === 'github.com/bitwarden/mobile'
   )
 
   const {

--- a/src/ducks/components/PushBanners/helpers.spec.js
+++ b/src/ducks/components/PushBanners/helpers.spec.js
@@ -23,12 +23,15 @@ describe('makePushBanner', () => {
     })
 
     it('when no oAuth client installed for FlagshipApp even if there is one for Pass mobile', () => {
-      const res = makePushBanner([{ software_id: 'io.cozy.pass.mobile' }], {
-        pushBanners: {
-          hideFlagshipApp: false,
-          hidePassMobile: false
+      const res = makePushBanner(
+        [{ software_id: 'github.com/bitwarden/mobile' }],
+        {
+          pushBanners: {
+            hideFlagshipApp: false,
+            hidePassMobile: false
+          }
         }
-      })
+      )
 
       expect(res).toBe('BannerForFlagshipApp')
     })
@@ -67,7 +70,10 @@ describe('makePushBanner', () => {
   describe('should return no banner', () => {
     it('when oAuth client installed for FlagshipApp and Pass', () => {
       const res = makePushBanner(
-        [{ software_id: 'amiral' }, { software_id: 'io.cozy.pass.mobile' }],
+        [
+          { software_id: 'amiral' },
+          { software_id: 'github.com/bitwarden/mobile' }
+        ],
         {
           pushBanners: {
             hideFlagshipApp: false,
@@ -91,12 +97,15 @@ describe('makePushBanner', () => {
     })
 
     it('when oAuth client installed for Pass and FlagshipApp banner already dismissed', () => {
-      const res = makePushBanner([{ software_id: 'io.cozy.pass.mobile' }], {
-        pushBanners: {
-          hideFlagshipApp: true,
-          hidePassMobile: false
+      const res = makePushBanner(
+        [{ software_id: 'github.com/bitwarden/mobile' }],
+        {
+          pushBanners: {
+            hideFlagshipApp: true,
+            hidePassMobile: false
+          }
         }
-      })
+      )
 
       expect(res).toBeNull()
     })

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -324,7 +324,7 @@
     "download": "Télécharger",
     "no-thanks": "Non merci !",
     "text": {
-      "flagshipApp": "Emportez votre cloud personnel avec vous : installer notre app Cozy !",
+      "flagshipApp": "Emportez votre cloud personnel avec vous : installez notre app Cozy !",
       "pass": "Vos mots de passe en sécurité dans votre poche : téléchargez Cozy Pass sur votre mobile"
     }
   }


### PR DESCRIPTION
Le software_id n'est pas utilisé côté stack, c'est ici que ça se passe https://github.com/cozy/cozy-stack/blob/master/model/bitwarden/oauth.go#L54-L87

Dans la solution retenue, on discrimine volontairement tous les clients mobile bitwarden, on se base donc sur `github.com/bitwarden/mobile`