### PR TITLE
fix: Keep selected section and filters when navigating between Sections page and Application pages

### DIFF
--- a/src/ducks/apps/components/ApplicationPage/Details.jsx
+++ b/src/ducks/apps/components/ApplicationPage/Details.jsx
@@ -34,21 +34,16 @@ export const Details = ({ app, description, changes, parent, mobileApps }) => {
   const { source, slug, langs, categories, developer, version } = app
 
   const appChannel = getChannel(source)
+  const isBeta = appChannel === REGISTRY_CHANNELS.BETA
+  const isDev = appChannel === REGISTRY_CHANNELS.DEV
 
   const client = useClient()
   const { t } = useI18n()
   const navigate = useNavigate()
   const { search } = useLocation()
+  const [displayBetaChannel, setDisplayBetaChannel] = useState(isBeta)
+  const [displayDevChannel, setDisplayDevChannel] = useState(isDev)
 
-  const [displayBetaChannel, setDisplayBetaChannel] = useState(
-    appChannel === REGISTRY_CHANNELS.BETA
-  )
-  const [displayDevChannel, setDisplayDevChannel] = useState(
-    appChannel === REGISTRY_CHANNELS.DEV
-  )
-
-  const isBeta = appChannel === REGISTRY_CHANNELS.BETA
-  const isDev = appChannel === REGISTRY_CHANNELS.DEV
   const langsInfos = langs && langs.map(l => t(`app_langs.${l}`))
   const categoriesInfos =
     categories &&

--- a/src/ducks/apps/components/ApplicationPage/Details.jsx
+++ b/src/ducks/apps/components/ApplicationPage/Details.jsx
@@ -124,13 +124,13 @@ export const Details = ({ app, description, changes, parent, mobileApps }) => {
             {t('app_page.infos.version.title')}
           </div>
           <div className="sto-app-info-content">
-            <span onDoubleClick={toggleChannels}>
+            <span onDoubleClick={toggleChannels} data-testid="toggleChannels">
               {displayedVersion || t('app_page.infos.version.unknown')}
             </span>
           </div>
         </div>
         {(displayBetaChannel || displayDevChannel) && (
-          <div className="sto-app-info">
+          <div className="sto-app-info" data-testid="betaToggle">
             <div className="sto-app-info-header">
               {t('app_page.infos.beta')}
             </div>
@@ -144,7 +144,7 @@ export const Details = ({ app, description, changes, parent, mobileApps }) => {
           </div>
         )}
         {displayDevChannel && (
-          <div className="sto-app-info">
+          <div className="sto-app-info" data-testid="devToggle">
             <div className="sto-app-info-header">{t('app_page.infos.dev')}</div>
             <div className="sto-app-info-content">
               <Toggle

--- a/src/ducks/apps/components/ApplicationPage/Details.jsx
+++ b/src/ducks/apps/components/ApplicationPage/Details.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 import { useClient } from 'cozy-client'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
@@ -38,6 +38,7 @@ export const Details = ({ app, description, changes, parent, mobileApps }) => {
   const client = useClient()
   const { t } = useI18n()
   const navigate = useNavigate()
+  const { search } = useLocation()
 
   const [displayBetaChannel, setDisplayBetaChannel] = useState(
     appChannel === REGISTRY_CHANNELS.BETA
@@ -62,7 +63,7 @@ export const Details = ({ app, description, changes, parent, mobileApps }) => {
     (shortVersion && shortVersion.length && shortVersion[1]) || version
 
   const onShowPermissions = () => {
-    navigate(`/${parent}/${app.slug}/permissions`)
+    navigate(`/${parent}/${app.slug}/permissions${search}`)
   }
 
   const toggleChannels = async () => {
@@ -87,7 +88,7 @@ export const Details = ({ app, description, changes, parent, mobileApps }) => {
 
   const onUpdateChannel = (checked, channel) => {
     const targetChannel = checked ? channel : REGISTRY_CHANNELS.STABLE
-    navigate(`/${parent}/${app.slug}/channel/${targetChannel}`)
+    navigate(`/${parent}/${app.slug}/channel/${targetChannel}${search}`)
   }
 
   return (

--- a/src/ducks/apps/components/ApplicationPage/Details.jsx
+++ b/src/ducks/apps/components/ApplicationPage/Details.jsx
@@ -1,8 +1,8 @@
-import React, { Component } from 'react'
+import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { withClient } from 'cozy-client'
-import { translate } from 'cozy-ui/transpiled/react/I18n'
+import { useClient } from 'cozy-client'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Button } from 'cozy-ui/transpiled/react/Button'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import Toggle from 'cozy-ui/transpiled/react/Toggle'
@@ -30,203 +30,192 @@ const isValidUrl = url => {
   )
 }
 
-export class Details extends Component {
-  constructor(props) {
-    super(props)
-    const { app } = this.props
-    const appChannel = getChannel(app.source)
-    this.state = {
-      displayBetaChannel: appChannel === REGISTRY_CHANNELS.BETA,
-      displayDevChannel: appChannel === REGISTRY_CHANNELS.DEV
-    }
+export const Details = ({ app, description, changes, parent, mobileApps }) => {
+  const { source, slug, langs, categories, developer, version } = app
 
-    this.toggleChannels = this.toggleChannels.bind(this)
-    this.onUpdateChannel = this.onUpdateChannel.bind(this)
+  const appChannel = getChannel(source)
+
+  const client = useClient()
+  const { t } = useI18n()
+  const navigate = useNavigate()
+
+  const [displayBetaChannel, setDisplayBetaChannel] = useState(
+    appChannel === REGISTRY_CHANNELS.BETA
+  )
+  const [displayDevChannel, setDisplayDevChannel] = useState(
+    appChannel === REGISTRY_CHANNELS.DEV
+  )
+
+  const isBeta = appChannel === REGISTRY_CHANNELS.BETA
+  const isDev = appChannel === REGISTRY_CHANNELS.DEV
+  const langsInfos = langs && langs.map(l => t(`app_langs.${l}`))
+  const categoriesInfos =
+    categories &&
+    !!categories.length &&
+    categories.map(c => t(`app_categories.${c}`))
+  const developerName =
+    developer && getTranslatedManifestProperty(app, 'developer.name', t)
+  const developerUrl =
+    developer && getTranslatedManifestProperty(app, 'developer.url', t)
+  const shortVersion = version && version.match(/^(\d+\.\d+\.\d+)-.*$/)
+  const displayedVersion =
+    (shortVersion && shortVersion.length && shortVersion[1]) || version
+
+  const onShowPermissions = () => {
+    navigate(`/${parent}/${app.slug}/permissions`)
   }
 
-  onShowPermissions() {
-    const { app, parent } = this.props
-    this.props.navigate(`/${parent}/${app.slug}/permissions`)
-  }
-
-  async toggleChannels() {
-    const { app } = this.props
+  const toggleChannels = async () => {
     // only for installed apps and apps from the registry
     if (!(app.installed && getChannel(app.source))) return
-    const stateUpdate = {}
-    if (!this.state.displayBetaChannel) {
-      stateUpdate.displayBetaChannel = true
-    }
-    if (!this.state.displayDevChannel) {
-      const context = await getContext(this.props.client)
-      if (context && context.attributes && context.attributes.debug) {
-        stateUpdate.displayDevChannel = true
+
+    const context = await getContext(client)
+
+    setDisplayBetaChannel(display => !display)
+    setDisplayDevChannel(display => {
+      if (
+        !display &&
+        context &&
+        context.attributes &&
+        context.attributes.debug
+      ) {
+        return true
       }
-    }
-    this.setState(() => stateUpdate)
+      return false
+    })
   }
 
-  onUpdateChannel(checked, channel) {
-    const { app, navigate, parent } = this.props
+  const onUpdateChannel = (checked, channel) => {
     const targetChannel = checked ? channel : REGISTRY_CHANNELS.STABLE
     navigate(`/${parent}/${app.slug}/channel/${targetChannel}`)
   }
 
-  render() {
-    const { t, app, description, changes, mobileApps } = this.props
-    const { displayBetaChannel, displayDevChannel } = this.state
-    const { source, slug, langs, categories, developer, version } = app
-    const appChannel = getChannel(source)
-    const isBeta = appChannel === REGISTRY_CHANNELS.BETA
-    const isDev = appChannel === REGISTRY_CHANNELS.DEV
-    const langsInfos = langs && langs.map(l => t(`app_langs.${l}`))
-    const categoriesInfos =
-      categories &&
-      !!categories.length &&
-      categories.map(c => t(`app_categories.${c}`))
-    const developerName =
-      developer && getTranslatedManifestProperty(app, 'developer.name', t)
-    const developerUrl =
-      developer && getTranslatedManifestProperty(app, 'developer.url', t)
-    const shortVersion = version && version.match(/^(\d+\.\d+\.\d+)-.*$/)
-    const displayedVersion =
-      (shortVersion && shortVersion.length && shortVersion[1]) || version
-    return (
-      <div className="sto-app-details">
-        <div className="sto-app-descriptions">
-          {isUnderMaintenance(app) && <Maintenance slug={slug} />}
-          {description && (
-            <div className="sto-app-description">
-              <h3 className="u-title-h3">{t('app_page.description')}</h3>
-              <ReactMarkdownWrapper source={description} parseEmoji />
-            </div>
-          )}
-          {changes && (
-            <div className="sto-app-changes">
-              <h3 className="u-title-h3">{t('app_page.changes')}</h3>
-              <ReactMarkdownWrapper source={changes} parseEmoji />
-            </div>
-          )}
+  return (
+    <div className="sto-app-details">
+      <div className="sto-app-descriptions">
+        {isUnderMaintenance(app) && <Maintenance slug={slug} />}
+        {description && (
+          <div className="sto-app-description">
+            <h3 className="u-title-h3">{t('app_page.description')}</h3>
+            <ReactMarkdownWrapper source={description} parseEmoji />
+          </div>
+        )}
+        {changes && (
+          <div className="sto-app-changes">
+            <h3 className="u-title-h3">{t('app_page.changes')}</h3>
+            <ReactMarkdownWrapper source={changes} parseEmoji />
+          </div>
+        )}
+      </div>
+      <div className="sto-app-additional-details">
+        <h3 className="u-title-h3">{t('app_page.infos.title')}</h3>
+        <div className="sto-app-info">
+          <div className="sto-app-info-header">
+            {t('app_page.infos.categories')}
+          </div>
+          <div className="sto-app-info-content">
+            {categoriesInfos &&
+              categoriesInfos.join(t('app_categories.list_separator'))}
+          </div>
         </div>
-        <div className="sto-app-additional-details">
-          <h3 className="u-title-h3">{t('app_page.infos.title')}</h3>
+        <div className="sto-app-info">
+          <div className="sto-app-info-header">
+            {t('app_page.infos.version.title')}
+          </div>
+          <div className="sto-app-info-content">
+            <span onDoubleClick={toggleChannels}>
+              {displayedVersion || t('app_page.infos.version.unknown')}
+            </span>
+          </div>
+        </div>
+        {(displayBetaChannel || displayDevChannel) && (
           <div className="sto-app-info">
             <div className="sto-app-info-header">
-              {t('app_page.infos.categories')}
+              {t('app_page.infos.beta')}
             </div>
             <div className="sto-app-info-content">
-              {categoriesInfos &&
-                categoriesInfos.join(t('app_categories.list_separator'))}
+              <Toggle
+                id={`sto-app-${slug}-beta-toggle`}
+                checked={isBeta}
+                onToggle={e => onUpdateChannel(e, REGISTRY_CHANNELS.BETA)}
+              />
             </div>
           </div>
+        )}
+        {displayDevChannel && (
+          <div className="sto-app-info">
+            <div className="sto-app-info-header">{t('app_page.infos.dev')}</div>
+            <div className="sto-app-info-content">
+              <Toggle
+                id={`sto-app-${slug}-dev-toggle`}
+                checked={isDev}
+                onToggle={e => onUpdateChannel(e, REGISTRY_CHANNELS.DEV)}
+              />
+            </div>
+          </div>
+        )}
+        {langsInfos && (
           <div className="sto-app-info">
             <div className="sto-app-info-header">
-              {t('app_page.infos.version.title')}
+              {t('app_page.infos.langs')}
             </div>
             <div className="sto-app-info-content">
-              <span onDoubleClick={this.toggleChannels}>
-                {displayedVersion || t('app_page.infos.version.unknown')}
-              </span>
+              {langsInfos.join(t('app_langs.list_separator'))}
             </div>
           </div>
-          {(displayBetaChannel || displayDevChannel) && (
-            <div className="sto-app-info">
-              <div className="sto-app-info-header">
-                {t('app_page.infos.beta')}
-              </div>
-              <div className="sto-app-info-content">
-                <Toggle
-                  id={`sto-app-${slug}-beta-toggle`}
-                  checked={isBeta}
-                  onToggle={e =>
-                    this.onUpdateChannel(e, REGISTRY_CHANNELS.BETA)
-                  }
-                />
-              </div>
+        )}
+        {mobileApps && !!mobileApps.length && (
+          <div className="sto-app-info">
+            <div className="sto-app-info-header">
+              {t('app_page.infos.mobile_app')}
             </div>
-          )}
-          {displayDevChannel && (
-            <div className="sto-app-info">
-              <div className="sto-app-info-header">
-                {t('app_page.infos.dev')}
-              </div>
-              <div className="sto-app-info-content">
-                <Toggle
-                  id={`sto-app-${slug}-dev-toggle`}
-                  checked={isDev}
-                  onToggle={e => this.onUpdateChannel(e, REGISTRY_CHANNELS.DEV)}
-                />
-              </div>
-            </div>
-          )}
-          {langsInfos && (
-            <div className="sto-app-info">
-              <div className="sto-app-info-header">
-                {t('app_page.infos.langs')}
-              </div>
-              <div className="sto-app-info-content">
-                {langsInfos.join(t('app_langs.list_separator'))}
-              </div>
-            </div>
-          )}
-          {mobileApps && !!mobileApps.length && (
-            <div className="sto-app-info">
-              <div className="sto-app-info-header">
-                {t('app_page.infos.mobile_app')}
-              </div>
-              <div className="sto-app-info-content sto-app-info-content--mobile-apps">
-                {mobileApps.map(a => {
-                  const icon = platformIcons[a.type]
-                  return (
-                    <a
-                      className="sto-app-info-content-icon"
-                      href={isValidUrl(a.url) ? a.url : null}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      key={a.type}
-                    >
-                      <Icon icon={icon} width="24px" height="24px" />
-                    </a>
-                  )
-                })}
-              </div>
-            </div>
-          )}
-          <div>
-            <Button
-              label={t('app_page.permissions.button.label')}
-              className="sto-app-permissions-button"
-              onClick={() => this.onShowPermissions()}
-              subtle
-            />
-          </div>
-          {developerName && (
-            <div>
-              <h3 className="u-title-h3">{t('app_page.developer_infos')}</h3>
-              <div className="sto-app-developer-infos">
-                <span>{developerName}</span>
-                {isValidUrl(developerUrl) && (
+            <div className="sto-app-info-content sto-app-info-content--mobile-apps">
+              {mobileApps.map(a => {
+                const icon = platformIcons[a.type]
+                return (
                   <a
-                    href={developerUrl}
-                    className="sto-app-developer-link"
+                    className="sto-app-info-content-icon"
+                    href={isValidUrl(a.url) ? a.url : null}
                     target="_blank"
                     rel="noopener noreferrer"
+                    key={a.type}
                   >
-                    {developerUrl}
+                    <Icon icon={icon} width="24px" height="24px" />
                   </a>
-                )}
-              </div>
+                )
+              })}
             </div>
-          )}
+          </div>
+        )}
+        <div>
+          <Button
+            label={t('app_page.permissions.button.label')}
+            className="sto-app-permissions-button"
+            onClick={() => onShowPermissions()}
+            subtle
+          />
         </div>
+        {developerName && (
+          <div>
+            <h3 className="u-title-h3">{t('app_page.developer_infos')}</h3>
+            <div className="sto-app-developer-infos">
+              <span>{developerName}</span>
+              {isValidUrl(developerUrl) && (
+                <a
+                  href={developerUrl}
+                  className="sto-app-developer-link"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {developerUrl}
+                </a>
+              )}
+            </div>
+          </div>
+        )}
       </div>
-    )
-  }
+    </div>
+  )
 }
 
-const DetailsWrapper = props => {
-  const navigate = useNavigate()
-  return <Details {...props} navigate={navigate} />
-}
-
-export default withClient(translate()(DetailsWrapper))
+export default Details

--- a/src/ducks/apps/components/ApplicationPage/index.jsx
+++ b/src/ducks/apps/components/ApplicationPage/index.jsx
@@ -1,6 +1,7 @@
 /* global cozy */
 import React, { Component } from 'react'
 import { Link, useMatch, useParams } from 'react-router-dom'
+import { useLocationNoUpdates } from 'lib/RouterUtils'
 
 import { withClient } from 'cozy-client'
 
@@ -79,6 +80,7 @@ export class ApplicationPage extends Component {
     const {
       t,
       parent,
+      search,
       params,
       isFetching,
       fetchError,
@@ -156,7 +158,7 @@ export class ApplicationPage extends Component {
             <Button
               icon={Left}
               tag={Link}
-              to={`/${parent}`}
+              to={`/${parent}${search}`}
               className="sto-app-back"
               label={t('app_page.back')}
               onClick={this.unmountTrap}
@@ -189,10 +191,16 @@ export class ApplicationPage extends Component {
 const ApplicationPageWrapper = props => {
   const { parent } = props
   const params = useParams()
+  const { search } = useLocationNoUpdates()
   const isExact = useMatch(`${parent}/:appSlug`)
 
   return (
-    <ApplicationPage {...props} params={params} pauseFocusTrap={!isExact} />
+    <ApplicationPage
+      {...props}
+      params={params}
+      search={search}
+      pauseFocusTrap={!isExact}
+    />
   )
 }
 

--- a/src/ducks/apps/components/ApplicationRouting/PermissionsRoute.jsx
+++ b/src/ducks/apps/components/ApplicationRouting/PermissionsRoute.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useParams } from 'react-router-dom'
+import { useLocation, useParams } from 'react-router-dom'
 
 import PermissionsModal from 'ducks/apps/components/PermissionsModal'
 
@@ -10,12 +10,13 @@ export const PermissionsRoute = ({
   redirectTo
 }) => {
   const params = useParams()
+  const { search } = useLocation()
 
   if (isFetching) return null
 
   const app = getApp(params)
 
-  if (!app) return redirectTo(`/${parent}`)
+  if (!app) return redirectTo(`/${parent}${search}`)
 
   return <PermissionsModal app={app} parent={`/${parent}`} />
 }

--- a/src/ducks/apps/components/Discover.jsx
+++ b/src/ducks/apps/components/Discover.jsx
@@ -38,7 +38,8 @@ export class Discover extends Component {
       }
     }
 
-    navigate(`/discover/${appSlug}`)
+    const search = searchParams.size > 0 ? `?${searchParams.toString()}` : ''
+    navigate(`/discover/${appSlug}${search}`)
   }
 
   render() {

--- a/src/ducks/apps/components/Discover.jsx
+++ b/src/ducks/apps/components/Discover.jsx
@@ -19,7 +19,6 @@ export class Discover extends Component {
   constructor(props) {
     super(props)
     this.onAppClick = this.onAppClick.bind(this)
-    this.pushQuery = this.pushQuery.bind(this)
   }
 
   onAppClick(appSlug) {
@@ -40,11 +39,6 @@ export class Discover extends Component {
     }
 
     navigate(`/discover/${appSlug}`)
-  }
-
-  pushQuery(query) {
-    if (!query) return this.props.navigate('/discover')
-    this.props.navigate(`/discover?${query}`)
   }
 
   render() {

--- a/src/ducks/apps/components/MyApplications.jsx
+++ b/src/ducks/apps/components/MyApplications.jsx
@@ -1,6 +1,6 @@
 /* global cozy */
 import React, { Component } from 'react'
-import { useMatch } from 'react-router-dom'
+import { useMatch, useSearchParams } from 'react-router-dom'
 
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
@@ -21,7 +21,10 @@ export class MyApplications extends Component {
   }
 
   onAppClick(appSlug) {
-    this.props.navigate(`/myapps/${appSlug}`)
+    const { searchParams } = this.props
+
+    const search = searchParams.size > 0 ? `?${searchParams.toString()}` : ''
+    this.props.navigate(`/myapps/${appSlug}${search}`)
   }
 
   render() {
@@ -67,8 +70,16 @@ export class MyApplications extends Component {
 const MyApplicationsWrapper = props => {
   const isExact = useMatch('myapps')
   const navigate = useNavigateNoUpdates()
+  const [searchParams] = useSearchParams()
 
-  return <MyApplications {...props} isExact={isExact} navigate={navigate} />
+  return (
+    <MyApplications
+      {...props}
+      isExact={isExact}
+      navigate={navigate}
+      searchParams={searchParams}
+    />
+  )
 }
 
 export default translate()(

--- a/src/ducks/apps/components/PermissionsModal.jsx
+++ b/src/ducks/apps/components/PermissionsModal.jsx
@@ -1,18 +1,20 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import Modal, {
   ModalContent,
   ModalHeader
 } from 'cozy-ui/transpiled/react/Modal'
-import { translate } from 'cozy-ui/transpiled/react/I18n'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Portal from 'cozy-ui/transpiled/react/Portal'
 
 import PermissionsList from 'ducks/apps/components/PermissionsList'
 
-export class PermissionsModal extends Component {
-  gotoParent() {
-    const { app, parent, navigate } = this.props
+export const PermissionsModal = ({ app, parent }) => {
+  const { t } = useI18n()
+  const navigate = useNavigate()
+
+  const gotoParent = () => {
     if (app && app.slug) {
       navigate(`${parent}/${app.slug}`)
     } else {
@@ -20,26 +22,18 @@ export class PermissionsModal extends Component {
     }
   }
 
-  render() {
-    const { t, app } = this.props
-    return (
-      <Portal into="body">
-        <Modal secondaryAction={() => this.gotoParent()} mobileFullscreen>
-          <ModalHeader className="sto-install-header">
-            <h2>{t('app_modal.permissions.title')}</h2>
-          </ModalHeader>
-          <ModalContent>
-            <PermissionsList app={app} />
-          </ModalContent>
-        </Modal>
-      </Portal>
-    )
-  }
+  return (
+    <Portal into="body">
+      <Modal secondaryAction={() => gotoParent()} mobileFullscreen>
+        <ModalHeader className="sto-install-header">
+          <h2>{t('app_modal.permissions.title')}</h2>
+        </ModalHeader>
+        <ModalContent>
+          <PermissionsList app={app} />
+        </ModalContent>
+      </Modal>
+    </Portal>
+  )
 }
 
-const PermissionsModalWrapper = props => {
-  const navigate = useNavigate()
-  return <PermissionsModal {...props} navigate={navigate} />
-}
-
-export default translate()(PermissionsModalWrapper)
+export default PermissionsModal

--- a/src/ducks/apps/components/PermissionsModal.jsx
+++ b/src/ducks/apps/components/PermissionsModal.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 import Modal, {
   ModalContent,
@@ -13,12 +13,13 @@ import PermissionsList from 'ducks/apps/components/PermissionsList'
 export const PermissionsModal = ({ app, parent }) => {
   const { t } = useI18n()
   const navigate = useNavigate()
+  const { search } = useLocation()
 
   const gotoParent = () => {
     if (app && app.slug) {
-      navigate(`${parent}/${app.slug}`)
+      navigate(`${parent}/${app.slug}${search}`)
     } else {
-      navigate(`${parent}`)
+      navigate(`${parent}${search}`)
     }
   }
 

--- a/src/ducks/apps/components/Sections/Sections.jsx
+++ b/src/ducks/apps/components/Sections/Sections.jsx
@@ -74,9 +74,9 @@ const Sections = ({
   useEffect(() => {
     const currentFilter = filter || internalFilter
     if (
-      !!previousFilter &&
-      (previousFilter.type !== currentFilter.type ||
-        previousFilter.category !== currentFilter.category)
+      !!previousFilter.current &&
+      (previousFilter.current.type !== currentFilter.type ||
+        previousFilter.current.category !== currentFilter.category)
     ) {
       setSearchFieldValue('')
     }

--- a/src/ducks/apps/components/SidebarCategories.jsx
+++ b/src/ducks/apps/components/SidebarCategories.jsx
@@ -5,12 +5,12 @@ import { NavLink as RouterLink, useLocation } from 'react-router-dom'
 
 import { categoryUtils } from 'cozy-ui/transpiled/react/AppSections'
 
-const getActiveChecker = (parent, cat, location) => {
+const getActiveChecker = (cat, location) => {
   const urlSearchParams = new URLSearchParams(location.search)
   const params = Object.fromEntries([...urlSearchParams])
+
   if (
-    (parent === location.pathname &&
-      (cat.value === params.category && cat.type === params.type)) ||
+    (cat.value === params.category && cat.type === params.type) ||
     (cat.value === 'konnectors' &&
       params.type === 'konnector' &&
       params.category === undefined)
@@ -21,8 +21,8 @@ const getActiveChecker = (parent, cat, location) => {
   return false
 }
 
-const renderLink = (parent, cat, path, location) => {
-  const isActive = getActiveChecker(parent, cat, location)
+const renderLink = (cat, path, location) => {
+  const isActive = getActiveChecker(cat, location)
 
   return (
     <li key={path}>
@@ -84,15 +84,9 @@ export const SidebarCategories = ({
   // compute sidebar categories links
   const linksArray = options.map(cat => {
     if (cat.value === 'konnectors') {
-      return renderLink(
-        parent,
-        cat,
-        `${parent}?type=konnector${extraParams}`,
-        location
-      )
+      return renderLink(cat, `${parent}?type=konnector${extraParams}`, location)
     } else {
       return renderLink(
-        parent,
         cat,
         `${parent}?type=${cat.type}&category=${cat.value}${extraParams}`,
         location

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -24,6 +24,7 @@
 .sto-side-menu-item.--secondary {
   font-size: .8rem;
   margin-left: .5rem;
+  padding-right: .5rem;
   font-weight: normal;
 }
 

--- a/test/ducks/apps/components/applicationPage/__snapshots__/details.spec.js.snap
+++ b/test/ducks/apps/components/applicationPage/__snapshots__/details.spec.js.snap
@@ -1,101 +1,103 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ApplicationPage details component should be rendered correctly provided app with no description, no platforms, no langs and no changes no version 1`] = `
-<div
-  className="sto-app-details"
->
+<div>
   <div
-    className="sto-app-descriptions"
+    class="sto-app-details"
   >
-    
-    
-  </div>
-  <div
-    className="sto-app-additional-details"
-  >
-    <h3
-      className="u-title-h3"
-    >
-      Informations
-    </h3>
     <div
-      className="sto-app-info"
+      class="sto-app-descriptions"
     >
-      <div
-        className="sto-app-info-header"
-      >
-        Categories
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        The essentials
-      </div>
+      
+      
     </div>
     <div
-      className="sto-app-info"
+      class="sto-app-additional-details"
     >
-      <div
-        className="sto-app-info-header"
-      >
-        Version
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        <span
-          onDoubleClick={[Function]}
-        >
-          0.1.0
-        </span>
-      </div>
-    </div>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Languages
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        English, French
-      </div>
-    </div>
-    <div>
-      <Button
-        align="center"
-        className="sto-app-permissions-button"
-        label="Show permissions"
-        onClick={[Function]}
-        size="normal"
-        subtle={true}
-        tag="button"
-        type="submit"
-      />
-    </div>
-    <div>
       <h3
-        className="u-title-h3"
+        class="u-title-h3"
       >
-        Developer Details
+        Informations
       </h3>
       <div
-        className="sto-app-developer-infos"
+        class="sto-app-info"
       >
-        <span>
-          Cozy
-        </span>
-        <a
-          className="sto-app-developer-link"
-          href="https://cozy.io"
-          rel="noopener noreferrer"
-          target="_blank"
+        <div
+          class="sto-app-info-header"
         >
-          https://cozy.io
-        </a>
+          Categories
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          The essentials
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Version
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          <span
+            data-testid="toggleChannels"
+          >
+            0.1.0
+          </span>
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Languages
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          English, French
+        </div>
+      </div>
+      <div>
+        <button
+          class="styles__c-btn___-2Vnj styles__c-btn--subtle___OknKf styles__c-btn--center___16_Xh sto-app-permissions-button"
+          type="submit"
+        >
+          <span>
+            <span>
+              Show permissions
+            </span>
+          </span>
+        </button>
+      </div>
+      <div>
+        <h3
+          class="u-title-h3"
+        >
+          Developer Details
+        </h3>
+        <div
+          class="sto-app-developer-infos"
+        >
+          <span>
+            Cozy
+          </span>
+          <a
+            class="sto-app-developer-link"
+            href="https://cozy.io"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            https://cozy.io
+          </a>
+        </div>
       </div>
     </div>
   </div>
@@ -103,168 +105,194 @@ exports[`ApplicationPage details component should be rendered correctly provided
 `;
 
 exports[`ApplicationPage details component should be rendered correctly with provided app 1`] = `
-<div
-  className="sto-app-details"
->
+<div>
   <div
-    className="sto-app-descriptions"
+    class="sto-app-details"
   >
     <div
-      className="sto-app-description"
+      class="sto-app-descriptions"
+    >
+      <div
+        class="sto-app-description"
+      >
+        <h3
+          class="u-title-h3"
+        >
+          Description
+        </h3>
+        <div>
+          <h3
+            class="md-title md-title--h3"
+          >
+            Features
+          </h3>
+          <p
+            class="md-paragraph"
+          >
+            Enjoy features to grab your data in you Cozy 
+            <span>
+              <img
+                class="emoji"
+                data-codepoints="1f389"
+                src="/emoji-data/img-apple-64/1f389.png"
+              />
+            </span>
+          </p>
+        </div>
+      </div>
+      <div
+        class="sto-app-changes"
+      >
+        <h3
+          class="u-title-h3"
+        >
+          What's New?
+        </h3>
+        <div>
+          <h3
+            class="md-title md-title--h3"
+          >
+            NEW!!!
+          </h3>
+          <p
+            class="md-paragraph"
+          >
+             Now on the cozy-store :tada
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      class="sto-app-additional-details"
     >
       <h3
-        className="u-title-h3"
+        class="u-title-h3"
       >
-        Description
-      </h3>
-      <ReactMarkdownWrapper
-        parseEmoji={true}
-        source="### Features
-
-Enjoy features to grab your data in you Cozy :tada:"
-      />
-    </div>
-    <div
-      className="sto-app-changes"
-    >
-      <h3
-        className="u-title-h3"
-      >
-        What's New?
-      </h3>
-      <ReactMarkdownWrapper
-        parseEmoji={true}
-        source="### NEW!!!
-
- Now on the cozy-store :tada"
-      />
-    </div>
-  </div>
-  <div
-    className="sto-app-additional-details"
-  >
-    <h3
-      className="u-title-h3"
-    >
-      Informations
-    </h3>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Categories
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        The essentials
-      </div>
-    </div>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Version
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        <span
-          onDoubleClick={[Function]}
-        >
-          0.1.0
-        </span>
-      </div>
-    </div>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Languages
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        English, French
-      </div>
-    </div>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Mobile Application
-      </div>
-      <div
-        className="sto-app-info-content sto-app-info-content--mobile-apps"
-      >
-        <a
-          className="sto-app-info-content-icon"
-          href={null}
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <Icon
-            height="24px"
-            icon="<svg><text>svg icon</text></svg>"
-            spin={false}
-            width="24px"
-          />
-        </a>
-        <a
-          className="sto-app-info-content-icon"
-          href="https://mock.app"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <Icon
-            height="24px"
-            icon="<svg><text>svg icon</text></svg>"
-            spin={false}
-            width="24px"
-          />
-        </a>
-      </div>
-    </div>
-    <div>
-      <Button
-        align="center"
-        className="sto-app-permissions-button"
-        label="Show permissions"
-        onClick={[Function]}
-        size="normal"
-        subtle={true}
-        tag="button"
-        type="submit"
-      />
-    </div>
-    <div>
-      <h3
-        className="u-title-h3"
-      >
-        Developer Details
+        Informations
       </h3>
       <div
-        className="sto-app-developer-infos"
+        class="sto-app-info"
       >
-        <span>
-          Cozy
-        </span>
-        <a
-          className="sto-app-developer-link"
-          href="https://cozy.io"
-          rel="noopener noreferrer"
-          target="_blank"
+        <div
+          class="sto-app-info-header"
         >
-          https://cozy.io
-        </a>
+          Categories
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          The essentials
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Version
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          <span
+            data-testid="toggleChannels"
+          >
+            0.1.0
+          </span>
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Languages
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          English, French
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Mobile Application
+        </div>
+        <div
+          class="sto-app-info-content sto-app-info-content--mobile-apps"
+        >
+          <a
+            class="sto-app-info-content-icon"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              class="styles__icon___23x3R"
+              height="24px"
+              width="24px"
+            >
+              <use
+                xlink:href="#<svg><text>svg icon</text></svg>"
+              />
+            </svg>
+          </a>
+          <a
+            class="sto-app-info-content-icon"
+            href="https://mock.app"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              class="styles__icon___23x3R"
+              height="24px"
+              width="24px"
+            >
+              <use
+                xlink:href="#<svg><text>svg icon</text></svg>"
+              />
+            </svg>
+          </a>
+        </div>
+      </div>
+      <div>
+        <button
+          class="styles__c-btn___-2Vnj styles__c-btn--subtle___OknKf styles__c-btn--center___16_Xh sto-app-permissions-button"
+          type="submit"
+        >
+          <span>
+            <span>
+              Show permissions
+            </span>
+          </span>
+        </button>
+      </div>
+      <div>
+        <h3
+          class="u-title-h3"
+        >
+          Developer Details
+        </h3>
+        <div
+          class="sto-app-developer-infos"
+        >
+          <span>
+            Cozy
+          </span>
+          <a
+            class="sto-app-developer-link"
+            href="https://cozy.io"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            https://cozy.io
+          </a>
+        </div>
       </div>
     </div>
   </div>
@@ -272,98 +300,100 @@ Enjoy features to grab your data in you Cozy :tada:"
 `;
 
 exports[`ApplicationPage details component should be rendered correctly with provided konnector 1`] = `
-<div
-  className="sto-app-details"
->
+<div>
   <div
-    className="sto-app-descriptions"
-  />
-  <div
-    className="sto-app-additional-details"
+    class="sto-app-details"
   >
-    <h3
-      className="u-title-h3"
-    >
-      Informations
-    </h3>
     <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Categories
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        Transportation
-      </div>
-    </div>
+      class="sto-app-descriptions"
+    />
     <div
-      className="sto-app-info"
+      class="sto-app-additional-details"
     >
-      <div
-        className="sto-app-info-header"
-      >
-        Version
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        <span
-          onDoubleClick={[Function]}
-        >
-          Unknown
-        </span>
-      </div>
-    </div>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Languages
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        French, English
-      </div>
-    </div>
-    <div>
-      <Button
-        align="center"
-        className="sto-app-permissions-button"
-        label="Show permissions"
-        onClick={[Function]}
-        size="normal"
-        subtle={true}
-        tag="button"
-        type="submit"
-      />
-    </div>
-    <div>
       <h3
-        className="u-title-h3"
+        class="u-title-h3"
       >
-        Developer Details
+        Informations
       </h3>
       <div
-        className="sto-app-developer-infos"
+        class="sto-app-info"
       >
-        <span>
-          Cozy
-        </span>
-        <a
-          className="sto-app-developer-link"
-          href="https://cozy.io"
-          rel="noopener noreferrer"
-          target="_blank"
+        <div
+          class="sto-app-info-header"
         >
-          https://cozy.io
-        </a>
+          Categories
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          Transportation
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Version
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          <span
+            data-testid="toggleChannels"
+          >
+            Unknown
+          </span>
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Languages
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          French, English
+        </div>
+      </div>
+      <div>
+        <button
+          class="styles__c-btn___-2Vnj styles__c-btn--subtle___OknKf styles__c-btn--center___16_Xh sto-app-permissions-button"
+          type="submit"
+        >
+          <span>
+            <span>
+              Show permissions
+            </span>
+          </span>
+        </button>
+      </div>
+      <div>
+        <h3
+          class="u-title-h3"
+        >
+          Developer Details
+        </h3>
+        <div
+          class="sto-app-developer-infos"
+        >
+          <span>
+            Cozy
+          </span>
+          <a
+            class="sto-app-developer-link"
+            href="https://cozy.io"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            https://cozy.io
+          </a>
+        </div>
       </div>
     </div>
   </div>
@@ -371,204 +401,248 @@ exports[`ApplicationPage details component should be rendered correctly with pro
 `;
 
 exports[`ApplicationPage details component should handle channel switching if with installed app from registry provided 1`] = `
-<div
-  className="sto-app-details"
->
+<div>
   <div
-    className="sto-app-descriptions"
+    class="sto-app-details"
   >
     <div
-      className="sto-app-description"
+      class="sto-app-descriptions"
+    >
+      <div
+        class="sto-app-description"
+      >
+        <h3
+          class="u-title-h3"
+        >
+          Description
+        </h3>
+        <div>
+          <h3
+            class="md-title md-title--h3"
+          >
+            Features
+          </h3>
+          <p
+            class="md-paragraph"
+          >
+            Enjoy features to grab your data in you Cozy 
+            <span>
+              <img
+                class="emoji"
+                data-codepoints="1f389"
+                src="/emoji-data/img-apple-64/1f389.png"
+              />
+            </span>
+          </p>
+        </div>
+      </div>
+      <div
+        class="sto-app-changes"
+      >
+        <h3
+          class="u-title-h3"
+        >
+          What's New?
+        </h3>
+        <div>
+          <h3
+            class="md-title md-title--h3"
+          >
+            NEW!!!
+          </h3>
+          <p
+            class="md-paragraph"
+          >
+             Now on the cozy-store :tada
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      class="sto-app-additional-details"
     >
       <h3
-        className="u-title-h3"
+        class="u-title-h3"
       >
-        Description
-      </h3>
-      <ReactMarkdownWrapper
-        parseEmoji={true}
-        source="### Features
-
-Enjoy features to grab your data in you Cozy :tada:"
-      />
-    </div>
-    <div
-      className="sto-app-changes"
-    >
-      <h3
-        className="u-title-h3"
-      >
-        What's New?
-      </h3>
-      <ReactMarkdownWrapper
-        parseEmoji={true}
-        source="### NEW!!!
-
- Now on the cozy-store :tada"
-      />
-    </div>
-  </div>
-  <div
-    className="sto-app-additional-details"
-  >
-    <h3
-      className="u-title-h3"
-    >
-      Informations
-    </h3>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Categories
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        The essentials
-      </div>
-    </div>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Version
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        <span
-          onDoubleClick={[Function]}
-        >
-          0.1.0
-        </span>
-      </div>
-    </div>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Get Beta
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        <Toggle
-          checked={false}
-          id="sto-app-undefined-beta-toggle"
-          onToggle={[Function]}
-        />
-      </div>
-    </div>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Get Dev
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        <Toggle
-          checked={false}
-          id="sto-app-undefined-dev-toggle"
-          onToggle={[Function]}
-        />
-      </div>
-    </div>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Languages
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        English, French
-      </div>
-    </div>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Mobile Application
-      </div>
-      <div
-        className="sto-app-info-content sto-app-info-content--mobile-apps"
-      >
-        <a
-          className="sto-app-info-content-icon"
-          href={null}
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <Icon
-            height="24px"
-            icon="<svg><text>svg icon</text></svg>"
-            spin={false}
-            width="24px"
-          />
-        </a>
-        <a
-          className="sto-app-info-content-icon"
-          href="https://mock.app"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <Icon
-            height="24px"
-            icon="<svg><text>svg icon</text></svg>"
-            spin={false}
-            width="24px"
-          />
-        </a>
-      </div>
-    </div>
-    <div>
-      <Button
-        align="center"
-        className="sto-app-permissions-button"
-        label="Show permissions"
-        onClick={[Function]}
-        size="normal"
-        subtle={true}
-        tag="button"
-        type="submit"
-      />
-    </div>
-    <div>
-      <h3
-        className="u-title-h3"
-      >
-        Developer Details
+        Informations
       </h3>
       <div
-        className="sto-app-developer-infos"
+        class="sto-app-info"
       >
-        <span>
-          Cozy
-        </span>
-        <a
-          className="sto-app-developer-link"
-          href="https://cozy.io"
-          rel="noopener noreferrer"
-          target="_blank"
+        <div
+          class="sto-app-info-header"
         >
-          https://cozy.io
-        </a>
+          Categories
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          The essentials
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Version
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          <span
+            data-testid="toggleChannels"
+          >
+            0.1.0
+          </span>
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+        data-testid="betaToggle"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Get Beta
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          <span
+            class="styles__toggle___3zVsE"
+          >
+            <input
+              class="styles__checkbox___3ko96"
+              id="sto-app-undefined-beta-toggle"
+              type="checkbox"
+            />
+            <label
+              class="styles__label___3jY1f"
+              for="sto-app-undefined-beta-toggle"
+            />
+          </span>
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+        data-testid="devToggle"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Get Dev
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          <span
+            class="styles__toggle___3zVsE"
+          >
+            <input
+              class="styles__checkbox___3ko96"
+              id="sto-app-undefined-dev-toggle"
+              type="checkbox"
+            />
+            <label
+              class="styles__label___3jY1f"
+              for="sto-app-undefined-dev-toggle"
+            />
+          </span>
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Languages
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          English, French
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Mobile Application
+        </div>
+        <div
+          class="sto-app-info-content sto-app-info-content--mobile-apps"
+        >
+          <a
+            class="sto-app-info-content-icon"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              class="styles__icon___23x3R"
+              height="24px"
+              width="24px"
+            >
+              <use
+                xlink:href="#<svg><text>svg icon</text></svg>"
+              />
+            </svg>
+          </a>
+          <a
+            class="sto-app-info-content-icon"
+            href="https://mock.app"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              class="styles__icon___23x3R"
+              height="24px"
+              width="24px"
+            >
+              <use
+                xlink:href="#<svg><text>svg icon</text></svg>"
+              />
+            </svg>
+          </a>
+        </div>
+      </div>
+      <div>
+        <button
+          class="styles__c-btn___-2Vnj styles__c-btn--subtle___OknKf styles__c-btn--center___16_Xh sto-app-permissions-button"
+          type="submit"
+        >
+          <span>
+            <span>
+              Show permissions
+            </span>
+          </span>
+        </button>
+      </div>
+      <div>
+        <h3
+          class="u-title-h3"
+        >
+          Developer Details
+        </h3>
+        <div
+          class="sto-app-developer-infos"
+        >
+          <span>
+            Cozy
+          </span>
+          <a
+            class="sto-app-developer-link"
+            href="https://cozy.io"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            https://cozy.io
+          </a>
+        </div>
       </div>
     </div>
   </div>
@@ -576,186 +650,221 @@ Enjoy features to grab your data in you Cozy :tada:"
 `;
 
 exports[`ApplicationPage details component should not suggest Dev channel switching if the context is not in debug mode 1`] = `
-<div
-  className="sto-app-details"
->
+<div>
   <div
-    className="sto-app-descriptions"
+    class="sto-app-details"
   >
     <div
-      className="sto-app-description"
+      class="sto-app-descriptions"
+    >
+      <div
+        class="sto-app-description"
+      >
+        <h3
+          class="u-title-h3"
+        >
+          Description
+        </h3>
+        <div>
+          <h3
+            class="md-title md-title--h3"
+          >
+            Features
+          </h3>
+          <p
+            class="md-paragraph"
+          >
+            Enjoy features to grab your data in you Cozy 
+            <span>
+              <img
+                class="emoji"
+                data-codepoints="1f389"
+                src="/emoji-data/img-apple-64/1f389.png"
+              />
+            </span>
+          </p>
+        </div>
+      </div>
+      <div
+        class="sto-app-changes"
+      >
+        <h3
+          class="u-title-h3"
+        >
+          What's New?
+        </h3>
+        <div>
+          <h3
+            class="md-title md-title--h3"
+          >
+            NEW!!!
+          </h3>
+          <p
+            class="md-paragraph"
+          >
+             Now on the cozy-store :tada
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      class="sto-app-additional-details"
     >
       <h3
-        className="u-title-h3"
+        class="u-title-h3"
       >
-        Description
-      </h3>
-      <ReactMarkdownWrapper
-        parseEmoji={true}
-        source="### Features
-
-Enjoy features to grab your data in you Cozy :tada:"
-      />
-    </div>
-    <div
-      className="sto-app-changes"
-    >
-      <h3
-        className="u-title-h3"
-      >
-        What's New?
-      </h3>
-      <ReactMarkdownWrapper
-        parseEmoji={true}
-        source="### NEW!!!
-
- Now on the cozy-store :tada"
-      />
-    </div>
-  </div>
-  <div
-    className="sto-app-additional-details"
-  >
-    <h3
-      className="u-title-h3"
-    >
-      Informations
-    </h3>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Categories
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        The essentials
-      </div>
-    </div>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Version
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        <span
-          onDoubleClick={[Function]}
-        >
-          0.1.0
-        </span>
-      </div>
-    </div>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Get Beta
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        <Toggle
-          checked={false}
-          id="sto-app-undefined-beta-toggle"
-          onToggle={[Function]}
-        />
-      </div>
-    </div>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Languages
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        English, French
-      </div>
-    </div>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Mobile Application
-      </div>
-      <div
-        className="sto-app-info-content sto-app-info-content--mobile-apps"
-      >
-        <a
-          className="sto-app-info-content-icon"
-          href={null}
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <Icon
-            height="24px"
-            icon="<svg><text>svg icon</text></svg>"
-            spin={false}
-            width="24px"
-          />
-        </a>
-        <a
-          className="sto-app-info-content-icon"
-          href="https://mock.app"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <Icon
-            height="24px"
-            icon="<svg><text>svg icon</text></svg>"
-            spin={false}
-            width="24px"
-          />
-        </a>
-      </div>
-    </div>
-    <div>
-      <Button
-        align="center"
-        className="sto-app-permissions-button"
-        label="Show permissions"
-        onClick={[Function]}
-        size="normal"
-        subtle={true}
-        tag="button"
-        type="submit"
-      />
-    </div>
-    <div>
-      <h3
-        className="u-title-h3"
-      >
-        Developer Details
+        Informations
       </h3>
       <div
-        className="sto-app-developer-infos"
+        class="sto-app-info"
       >
-        <span>
-          Cozy
-        </span>
-        <a
-          className="sto-app-developer-link"
-          href="https://cozy.io"
-          rel="noopener noreferrer"
-          target="_blank"
+        <div
+          class="sto-app-info-header"
         >
-          https://cozy.io
-        </a>
+          Categories
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          The essentials
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Version
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          <span
+            data-testid="toggleChannels"
+          >
+            0.1.0
+          </span>
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+        data-testid="betaToggle"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Get Beta
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          <span
+            class="styles__toggle___3zVsE"
+          >
+            <input
+              class="styles__checkbox___3ko96"
+              id="sto-app-undefined-beta-toggle"
+              type="checkbox"
+            />
+            <label
+              class="styles__label___3jY1f"
+              for="sto-app-undefined-beta-toggle"
+            />
+          </span>
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Languages
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          English, French
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Mobile Application
+        </div>
+        <div
+          class="sto-app-info-content sto-app-info-content--mobile-apps"
+        >
+          <a
+            class="sto-app-info-content-icon"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              class="styles__icon___23x3R"
+              height="24px"
+              width="24px"
+            >
+              <use
+                xlink:href="#<svg><text>svg icon</text></svg>"
+              />
+            </svg>
+          </a>
+          <a
+            class="sto-app-info-content-icon"
+            href="https://mock.app"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              class="styles__icon___23x3R"
+              height="24px"
+              width="24px"
+            >
+              <use
+                xlink:href="#<svg><text>svg icon</text></svg>"
+              />
+            </svg>
+          </a>
+        </div>
+      </div>
+      <div>
+        <button
+          class="styles__c-btn___-2Vnj styles__c-btn--subtle___OknKf styles__c-btn--center___16_Xh sto-app-permissions-button"
+          type="submit"
+        >
+          <span>
+            <span>
+              Show permissions
+            </span>
+          </span>
+        </button>
+      </div>
+      <div>
+        <h3
+          class="u-title-h3"
+        >
+          Developer Details
+        </h3>
+        <div
+          class="sto-app-developer-infos"
+        >
+          <span>
+            Cozy
+          </span>
+          <a
+            class="sto-app-developer-link"
+            href="https://cozy.io"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            https://cozy.io
+          </a>
+        </div>
       </div>
     </div>
   </div>
@@ -763,168 +872,194 @@ Enjoy features to grab your data in you Cozy :tada:"
 `;
 
 exports[`ApplicationPage details component should not suggest channel switching if the app is not from registry and not installed 1`] = `
-<div
-  className="sto-app-details"
->
+<div>
   <div
-    className="sto-app-descriptions"
+    class="sto-app-details"
   >
     <div
-      className="sto-app-description"
+      class="sto-app-descriptions"
+    >
+      <div
+        class="sto-app-description"
+      >
+        <h3
+          class="u-title-h3"
+        >
+          Description
+        </h3>
+        <div>
+          <h3
+            class="md-title md-title--h3"
+          >
+            Features
+          </h3>
+          <p
+            class="md-paragraph"
+          >
+            Enjoy features to grab your data in you Cozy 
+            <span>
+              <img
+                class="emoji"
+                data-codepoints="1f389"
+                src="/emoji-data/img-apple-64/1f389.png"
+              />
+            </span>
+          </p>
+        </div>
+      </div>
+      <div
+        class="sto-app-changes"
+      >
+        <h3
+          class="u-title-h3"
+        >
+          What's New?
+        </h3>
+        <div>
+          <h3
+            class="md-title md-title--h3"
+          >
+            NEW!!!
+          </h3>
+          <p
+            class="md-paragraph"
+          >
+             Now on the cozy-store :tada
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      class="sto-app-additional-details"
     >
       <h3
-        className="u-title-h3"
+        class="u-title-h3"
       >
-        Description
-      </h3>
-      <ReactMarkdownWrapper
-        parseEmoji={true}
-        source="### Features
-
-Enjoy features to grab your data in you Cozy :tada:"
-      />
-    </div>
-    <div
-      className="sto-app-changes"
-    >
-      <h3
-        className="u-title-h3"
-      >
-        What's New?
-      </h3>
-      <ReactMarkdownWrapper
-        parseEmoji={true}
-        source="### NEW!!!
-
- Now on the cozy-store :tada"
-      />
-    </div>
-  </div>
-  <div
-    className="sto-app-additional-details"
-  >
-    <h3
-      className="u-title-h3"
-    >
-      Informations
-    </h3>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Categories
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        The essentials
-      </div>
-    </div>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Version
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        <span
-          onDoubleClick={[Function]}
-        >
-          0.1.0
-        </span>
-      </div>
-    </div>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Languages
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        English, French
-      </div>
-    </div>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Mobile Application
-      </div>
-      <div
-        className="sto-app-info-content sto-app-info-content--mobile-apps"
-      >
-        <a
-          className="sto-app-info-content-icon"
-          href={null}
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <Icon
-            height="24px"
-            icon="<svg><text>svg icon</text></svg>"
-            spin={false}
-            width="24px"
-          />
-        </a>
-        <a
-          className="sto-app-info-content-icon"
-          href="https://mock.app"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <Icon
-            height="24px"
-            icon="<svg><text>svg icon</text></svg>"
-            spin={false}
-            width="24px"
-          />
-        </a>
-      </div>
-    </div>
-    <div>
-      <Button
-        align="center"
-        className="sto-app-permissions-button"
-        label="Show permissions"
-        onClick={[Function]}
-        size="normal"
-        subtle={true}
-        tag="button"
-        type="submit"
-      />
-    </div>
-    <div>
-      <h3
-        className="u-title-h3"
-      >
-        Developer Details
+        Informations
       </h3>
       <div
-        className="sto-app-developer-infos"
+        class="sto-app-info"
       >
-        <span>
-          Cozy
-        </span>
-        <a
-          className="sto-app-developer-link"
-          href="https://cozy.io"
-          rel="noopener noreferrer"
-          target="_blank"
+        <div
+          class="sto-app-info-header"
         >
-          https://cozy.io
-        </a>
+          Categories
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          The essentials
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Version
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          <span
+            data-testid="toggleChannels"
+          >
+            0.1.0
+          </span>
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Languages
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          English, French
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Mobile Application
+        </div>
+        <div
+          class="sto-app-info-content sto-app-info-content--mobile-apps"
+        >
+          <a
+            class="sto-app-info-content-icon"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              class="styles__icon___23x3R"
+              height="24px"
+              width="24px"
+            >
+              <use
+                xlink:href="#<svg><text>svg icon</text></svg>"
+              />
+            </svg>
+          </a>
+          <a
+            class="sto-app-info-content-icon"
+            href="https://mock.app"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              class="styles__icon___23x3R"
+              height="24px"
+              width="24px"
+            >
+              <use
+                xlink:href="#<svg><text>svg icon</text></svg>"
+              />
+            </svg>
+          </a>
+        </div>
+      </div>
+      <div>
+        <button
+          class="styles__c-btn___-2Vnj styles__c-btn--subtle___OknKf styles__c-btn--center___16_Xh sto-app-permissions-button"
+          type="submit"
+        >
+          <span>
+            <span>
+              Show permissions
+            </span>
+          </span>
+        </button>
+      </div>
+      <div>
+        <h3
+          class="u-title-h3"
+        >
+          Developer Details
+        </h3>
+        <div
+          class="sto-app-developer-infos"
+        >
+          <span>
+            Cozy
+          </span>
+          <a
+            class="sto-app-developer-link"
+            href="https://cozy.io"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            https://cozy.io
+          </a>
+        </div>
       </div>
     </div>
   </div>
@@ -932,168 +1067,194 @@ Enjoy features to grab your data in you Cozy :tada:"
 `;
 
 exports[`ApplicationPage details component should not suggest channel switching if the app is not installed 1`] = `
-<div
-  className="sto-app-details"
->
+<div>
   <div
-    className="sto-app-descriptions"
+    class="sto-app-details"
   >
     <div
-      className="sto-app-description"
+      class="sto-app-descriptions"
+    >
+      <div
+        class="sto-app-description"
+      >
+        <h3
+          class="u-title-h3"
+        >
+          Description
+        </h3>
+        <div>
+          <h3
+            class="md-title md-title--h3"
+          >
+            Features
+          </h3>
+          <p
+            class="md-paragraph"
+          >
+            Enjoy features to grab your data in you Cozy 
+            <span>
+              <img
+                class="emoji"
+                data-codepoints="1f389"
+                src="/emoji-data/img-apple-64/1f389.png"
+              />
+            </span>
+          </p>
+        </div>
+      </div>
+      <div
+        class="sto-app-changes"
+      >
+        <h3
+          class="u-title-h3"
+        >
+          What's New?
+        </h3>
+        <div>
+          <h3
+            class="md-title md-title--h3"
+          >
+            NEW!!!
+          </h3>
+          <p
+            class="md-paragraph"
+          >
+             Now on the cozy-store :tada
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      class="sto-app-additional-details"
     >
       <h3
-        className="u-title-h3"
+        class="u-title-h3"
       >
-        Description
-      </h3>
-      <ReactMarkdownWrapper
-        parseEmoji={true}
-        source="### Features
-
-Enjoy features to grab your data in you Cozy :tada:"
-      />
-    </div>
-    <div
-      className="sto-app-changes"
-    >
-      <h3
-        className="u-title-h3"
-      >
-        What's New?
-      </h3>
-      <ReactMarkdownWrapper
-        parseEmoji={true}
-        source="### NEW!!!
-
- Now on the cozy-store :tada"
-      />
-    </div>
-  </div>
-  <div
-    className="sto-app-additional-details"
-  >
-    <h3
-      className="u-title-h3"
-    >
-      Informations
-    </h3>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Categories
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        The essentials
-      </div>
-    </div>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Version
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        <span
-          onDoubleClick={[Function]}
-        >
-          0.1.0
-        </span>
-      </div>
-    </div>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Languages
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        English, French
-      </div>
-    </div>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Mobile Application
-      </div>
-      <div
-        className="sto-app-info-content sto-app-info-content--mobile-apps"
-      >
-        <a
-          className="sto-app-info-content-icon"
-          href={null}
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <Icon
-            height="24px"
-            icon="<svg><text>svg icon</text></svg>"
-            spin={false}
-            width="24px"
-          />
-        </a>
-        <a
-          className="sto-app-info-content-icon"
-          href="https://mock.app"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <Icon
-            height="24px"
-            icon="<svg><text>svg icon</text></svg>"
-            spin={false}
-            width="24px"
-          />
-        </a>
-      </div>
-    </div>
-    <div>
-      <Button
-        align="center"
-        className="sto-app-permissions-button"
-        label="Show permissions"
-        onClick={[Function]}
-        size="normal"
-        subtle={true}
-        tag="button"
-        type="submit"
-      />
-    </div>
-    <div>
-      <h3
-        className="u-title-h3"
-      >
-        Developer Details
+        Informations
       </h3>
       <div
-        className="sto-app-developer-infos"
+        class="sto-app-info"
       >
-        <span>
-          Cozy
-        </span>
-        <a
-          className="sto-app-developer-link"
-          href="https://cozy.io"
-          rel="noopener noreferrer"
-          target="_blank"
+        <div
+          class="sto-app-info-header"
         >
-          https://cozy.io
-        </a>
+          Categories
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          The essentials
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Version
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          <span
+            data-testid="toggleChannels"
+          >
+            0.1.0
+          </span>
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Languages
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          English, French
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Mobile Application
+        </div>
+        <div
+          class="sto-app-info-content sto-app-info-content--mobile-apps"
+        >
+          <a
+            class="sto-app-info-content-icon"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              class="styles__icon___23x3R"
+              height="24px"
+              width="24px"
+            >
+              <use
+                xlink:href="#<svg><text>svg icon</text></svg>"
+              />
+            </svg>
+          </a>
+          <a
+            class="sto-app-info-content-icon"
+            href="https://mock.app"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              class="styles__icon___23x3R"
+              height="24px"
+              width="24px"
+            >
+              <use
+                xlink:href="#<svg><text>svg icon</text></svg>"
+              />
+            </svg>
+          </a>
+        </div>
+      </div>
+      <div>
+        <button
+          class="styles__c-btn___-2Vnj styles__c-btn--subtle___OknKf styles__c-btn--center___16_Xh sto-app-permissions-button"
+          type="submit"
+        >
+          <span>
+            <span>
+              Show permissions
+            </span>
+          </span>
+        </button>
+      </div>
+      <div>
+        <h3
+          class="u-title-h3"
+        >
+          Developer Details
+        </h3>
+        <div
+          class="sto-app-developer-infos"
+        >
+          <span>
+            Cozy
+          </span>
+          <a
+            class="sto-app-developer-link"
+            href="https://cozy.io"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            https://cozy.io
+          </a>
+        </div>
       </div>
     </div>
   </div>
@@ -1101,168 +1262,194 @@ Enjoy features to grab your data in you Cozy :tada:"
 `;
 
 exports[`ApplicationPage details component should not suggest channel switching if the installed app is not from registry 1`] = `
-<div
-  className="sto-app-details"
->
+<div>
   <div
-    className="sto-app-descriptions"
+    class="sto-app-details"
   >
     <div
-      className="sto-app-description"
+      class="sto-app-descriptions"
+    >
+      <div
+        class="sto-app-description"
+      >
+        <h3
+          class="u-title-h3"
+        >
+          Description
+        </h3>
+        <div>
+          <h3
+            class="md-title md-title--h3"
+          >
+            Features
+          </h3>
+          <p
+            class="md-paragraph"
+          >
+            Enjoy features to grab your data in you Cozy 
+            <span>
+              <img
+                class="emoji"
+                data-codepoints="1f389"
+                src="/emoji-data/img-apple-64/1f389.png"
+              />
+            </span>
+          </p>
+        </div>
+      </div>
+      <div
+        class="sto-app-changes"
+      >
+        <h3
+          class="u-title-h3"
+        >
+          What's New?
+        </h3>
+        <div>
+          <h3
+            class="md-title md-title--h3"
+          >
+            NEW!!!
+          </h3>
+          <p
+            class="md-paragraph"
+          >
+             Now on the cozy-store :tada
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      class="sto-app-additional-details"
     >
       <h3
-        className="u-title-h3"
+        class="u-title-h3"
       >
-        Description
-      </h3>
-      <ReactMarkdownWrapper
-        parseEmoji={true}
-        source="### Features
-
-Enjoy features to grab your data in you Cozy :tada:"
-      />
-    </div>
-    <div
-      className="sto-app-changes"
-    >
-      <h3
-        className="u-title-h3"
-      >
-        What's New?
-      </h3>
-      <ReactMarkdownWrapper
-        parseEmoji={true}
-        source="### NEW!!!
-
- Now on the cozy-store :tada"
-      />
-    </div>
-  </div>
-  <div
-    className="sto-app-additional-details"
-  >
-    <h3
-      className="u-title-h3"
-    >
-      Informations
-    </h3>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Categories
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        The essentials
-      </div>
-    </div>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Version
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        <span
-          onDoubleClick={[Function]}
-        >
-          0.1.0
-        </span>
-      </div>
-    </div>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Languages
-      </div>
-      <div
-        className="sto-app-info-content"
-      >
-        English, French
-      </div>
-    </div>
-    <div
-      className="sto-app-info"
-    >
-      <div
-        className="sto-app-info-header"
-      >
-        Mobile Application
-      </div>
-      <div
-        className="sto-app-info-content sto-app-info-content--mobile-apps"
-      >
-        <a
-          className="sto-app-info-content-icon"
-          href={null}
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <Icon
-            height="24px"
-            icon="<svg><text>svg icon</text></svg>"
-            spin={false}
-            width="24px"
-          />
-        </a>
-        <a
-          className="sto-app-info-content-icon"
-          href="https://mock.app"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <Icon
-            height="24px"
-            icon="<svg><text>svg icon</text></svg>"
-            spin={false}
-            width="24px"
-          />
-        </a>
-      </div>
-    </div>
-    <div>
-      <Button
-        align="center"
-        className="sto-app-permissions-button"
-        label="Show permissions"
-        onClick={[Function]}
-        size="normal"
-        subtle={true}
-        tag="button"
-        type="submit"
-      />
-    </div>
-    <div>
-      <h3
-        className="u-title-h3"
-      >
-        Developer Details
+        Informations
       </h3>
       <div
-        className="sto-app-developer-infos"
+        class="sto-app-info"
       >
-        <span>
-          Cozy
-        </span>
-        <a
-          className="sto-app-developer-link"
-          href="https://cozy.io"
-          rel="noopener noreferrer"
-          target="_blank"
+        <div
+          class="sto-app-info-header"
         >
-          https://cozy.io
-        </a>
+          Categories
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          The essentials
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Version
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          <span
+            data-testid="toggleChannels"
+          >
+            0.1.0
+          </span>
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Languages
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          English, French
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Mobile Application
+        </div>
+        <div
+          class="sto-app-info-content sto-app-info-content--mobile-apps"
+        >
+          <a
+            class="sto-app-info-content-icon"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              class="styles__icon___23x3R"
+              height="24px"
+              width="24px"
+            >
+              <use
+                xlink:href="#<svg><text>svg icon</text></svg>"
+              />
+            </svg>
+          </a>
+          <a
+            class="sto-app-info-content-icon"
+            href="https://mock.app"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              class="styles__icon___23x3R"
+              height="24px"
+              width="24px"
+            >
+              <use
+                xlink:href="#<svg><text>svg icon</text></svg>"
+              />
+            </svg>
+          </a>
+        </div>
+      </div>
+      <div>
+        <button
+          class="styles__c-btn___-2Vnj styles__c-btn--subtle___OknKf styles__c-btn--center___16_Xh sto-app-permissions-button"
+          type="submit"
+        >
+          <span>
+            <span>
+              Show permissions
+            </span>
+          </span>
+        </button>
+      </div>
+      <div>
+        <h3
+          class="u-title-h3"
+        >
+          Developer Details
+        </h3>
+        <div
+          class="sto-app-developer-infos"
+        >
+          <span>
+            Cozy
+          </span>
+          <a
+            class="sto-app-developer-link"
+            href="https://cozy.io"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            https://cozy.io
+          </a>
+        </div>
       </div>
     </div>
   </div>

--- a/test/ducks/apps/components/applicationPage/__snapshots__/index.spec.js.snap
+++ b/test/ducks/apps/components/applicationPage/__snapshots__/index.spec.js.snap
@@ -1624,6 +1624,298 @@ exports[`ApplicationPage component should be rendered correctly without app desc
 </FocusTrap>
 `;
 
+exports[`ApplicationPage component should put search content on back button URL 1`] = `
+<FocusTrap
+  _createFocusTrap={[Function]}
+  active={true}
+  focusTrapOptions={
+    Object {
+      "clickOutsideDeactivates": true,
+      "onDeactivate": [Function],
+    }
+  }
+  paused={false}
+  tag="div"
+>
+  <div
+    className="sto-modal-page-app"
+  >
+    <div
+      className="sto-app"
+    >
+      <DefaultButton
+        className="sto-app-back"
+        icon={[Function]}
+        label="Back to the list"
+        onClick={[Function]}
+        subtle={true}
+        tag={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "displayName": "Link",
+            "render": [Function],
+          }
+        }
+        to="//myappstype=konnector&category=isp"
+      />
+      <Connect(withBreakpoints(withI18n(withClient(Header))))
+        app={
+          Object {
+            "categories": Array [
+              "cozy",
+            ],
+            "developer": Object {
+              "name": "Cozy",
+              "url": "https://cozy.io",
+            },
+            "editor": "Cozy",
+            "icon": "https://mockcozy.cc/registry/photos/icon",
+            "installed": true,
+            "langs": Array [
+              "en",
+              "fr",
+            ],
+            "licence": "AGPL-3.0",
+            "locales": Object {
+              "en": Object {
+                "changes": "### NEW!!!
+
+ Now on the cozy-store :tada",
+                "long_description": "### Features
+
+Enjoy features to grab your data in you Cozy :tada:",
+                "short_description": "Gestionnaire de photos pour Cozy v3",
+              },
+              "fr": Object {
+                "long_description": "### Photos
+
+Gestionnaire de photos pour Cozy v3 :tada:",
+                "short_description": "Gestionnaire de photos pour Cozy v3",
+              },
+            },
+            "name": "Photos",
+            "name_prefix": "Cozy",
+            "permissions": Object {
+              "albums": Object {
+                "description": "Required to manage photos albums",
+                "methods": Array [
+                  "GET",
+                  "POST",
+                  "PUT",
+                ],
+                "type": "io.cozy.photos.albums",
+              },
+              "apps": Object {
+                "description": "Required by the cozy-bar to display the icons of the apps",
+                "type": "io.cozy.apps",
+                "verbs": Array [
+                  "GET",
+                ],
+              },
+              "contacts": Object {
+                "description": "Required to to share photos with your contacts",
+                "methods": Array [
+                  "GET",
+                  "POST",
+                ],
+                "type": "io.cozy.contacts",
+              },
+              "files": Object {
+                "description": "Required for photo access",
+                "methods": Array [
+                  "GET",
+                  "POST",
+                  "PUT",
+                ],
+                "type": "io.cozy.files",
+              },
+              "settings": Object {
+                "description": "Required by the cozy-bar to display Claudy and know which applications are coming soon",
+                "type": "io.cozy.settings",
+                "verbs": Array [
+                  "GET",
+                ],
+              },
+            },
+            "platforms": Array [
+              Object {
+                "type": "ios",
+                "url": "",
+              },
+              Object {
+                "type": "linux",
+                "url": "",
+              },
+              Object {
+                "type": "android",
+                "url": "https://mock.app",
+              },
+            ],
+            "related": "https://photos.mockcozy.cc",
+            "routes": Object {
+              "/": Object {
+                "folder": "/",
+                "index": "index.html",
+                "public": false,
+              },
+              "/public": Object {
+                "folder": "/public",
+                "index": "index.html",
+                "public": true,
+              },
+            },
+            "screenshots": Array [],
+            "short_description": "Photos manager for Cozy v3",
+            "slug": "photos",
+            "source": "https://github.com/cozy/cozy-drive.git@build-photos",
+            "type": "webapp",
+            "version": "3.0.0",
+          }
+        }
+        description="Gestionnaire de photos pour Cozy v3"
+        name="Photos"
+        namePrefix="Cozy"
+        parent="/myapps"
+      />
+      <Details
+        app={
+          Object {
+            "categories": Array [
+              "cozy",
+            ],
+            "developer": Object {
+              "name": "Cozy",
+              "url": "https://cozy.io",
+            },
+            "editor": "Cozy",
+            "icon": "https://mockcozy.cc/registry/photos/icon",
+            "installed": true,
+            "langs": Array [
+              "en",
+              "fr",
+            ],
+            "licence": "AGPL-3.0",
+            "locales": Object {
+              "en": Object {
+                "changes": "### NEW!!!
+
+ Now on the cozy-store :tada",
+                "long_description": "### Features
+
+Enjoy features to grab your data in you Cozy :tada:",
+                "short_description": "Gestionnaire de photos pour Cozy v3",
+              },
+              "fr": Object {
+                "long_description": "### Photos
+
+Gestionnaire de photos pour Cozy v3 :tada:",
+                "short_description": "Gestionnaire de photos pour Cozy v3",
+              },
+            },
+            "name": "Photos",
+            "name_prefix": "Cozy",
+            "permissions": Object {
+              "albums": Object {
+                "description": "Required to manage photos albums",
+                "methods": Array [
+                  "GET",
+                  "POST",
+                  "PUT",
+                ],
+                "type": "io.cozy.photos.albums",
+              },
+              "apps": Object {
+                "description": "Required by the cozy-bar to display the icons of the apps",
+                "type": "io.cozy.apps",
+                "verbs": Array [
+                  "GET",
+                ],
+              },
+              "contacts": Object {
+                "description": "Required to to share photos with your contacts",
+                "methods": Array [
+                  "GET",
+                  "POST",
+                ],
+                "type": "io.cozy.contacts",
+              },
+              "files": Object {
+                "description": "Required for photo access",
+                "methods": Array [
+                  "GET",
+                  "POST",
+                  "PUT",
+                ],
+                "type": "io.cozy.files",
+              },
+              "settings": Object {
+                "description": "Required by the cozy-bar to display Claudy and know which applications are coming soon",
+                "type": "io.cozy.settings",
+                "verbs": Array [
+                  "GET",
+                ],
+              },
+            },
+            "platforms": Array [
+              Object {
+                "type": "ios",
+                "url": "",
+              },
+              Object {
+                "type": "linux",
+                "url": "",
+              },
+              Object {
+                "type": "android",
+                "url": "https://mock.app",
+              },
+            ],
+            "related": "https://photos.mockcozy.cc",
+            "routes": Object {
+              "/": Object {
+                "folder": "/",
+                "index": "index.html",
+                "public": false,
+              },
+              "/public": Object {
+                "folder": "/public",
+                "index": "index.html",
+                "public": true,
+              },
+            },
+            "screenshots": Array [],
+            "short_description": "Photos manager for Cozy v3",
+            "slug": "photos",
+            "source": "https://github.com/cozy/cozy-drive.git@build-photos",
+            "type": "webapp",
+            "version": "3.0.0",
+          }
+        }
+        changes="### NEW!!!
+
+ Now on the cozy-store :tada"
+        description="### Features
+
+Enjoy features to grab your data in you Cozy :tada:"
+        mobileApps={
+          Array [
+            Object {
+              "type": "ios",
+              "url": "",
+            },
+            Object {
+              "type": "android",
+              "url": "https://mock.app",
+            },
+          ]
+        }
+        parent="/myapps"
+      />
+    </div>
+  </div>
+</FocusTrap>
+`;
+
 exports[`ApplicationPage component should render correctly an error message if fetchError 1`] = `
 <p
   className="u-error"

--- a/test/ducks/apps/components/applicationPage/__snapshots__/index.spec.js.snap
+++ b/test/ducks/apps/components/applicationPage/__snapshots__/index.spec.js.snap
@@ -153,7 +153,7 @@ Gestionnaire de photos pour Cozy v3 :tada:",
         namePrefix="Cozy"
         parent="/myapps"
       />
-      <withClient(withI18n(DetailsWrapper))
+      <Details
         app={
           Object {
             "categories": Array [
@@ -455,7 +455,7 @@ Gestionnaire de photos pour Cozy v3 :tada:",
         }
         slug="photos"
       />
-      <withClient(withI18n(DetailsWrapper))
+      <Details
         app={
           Object {
             "categories": Array [
@@ -734,7 +734,7 @@ exports[`ApplicationPage component should be rendered correctly with konnector i
         namePrefix=""
         parent="/myapps"
       />
-      <withClient(withI18n(DetailsWrapper))
+      <Details
         app={
           Object {
             "categories": Array [
@@ -995,7 +995,7 @@ Gestionnaire de photos pour Cozy v3 :tada:",
         namePrefix="Cozy"
         parent="/myapps"
       />
-      <withClient(withI18n(DetailsWrapper))
+      <Details
         app={
           Object {
             "categories": Array [
@@ -1272,7 +1272,7 @@ exports[`ApplicationPage component should be rendered correctly with provided in
         namePrefix=""
         parent="/myapps"
       />
-      <withClient(withI18n(DetailsWrapper))
+      <Details
         app={
           Object {
             "categories": Array [
@@ -1517,7 +1517,7 @@ exports[`ApplicationPage component should be rendered correctly without app desc
         namePrefix=""
         parent="/myapps"
       />
-      <withClient(withI18n(DetailsWrapper))
+      <Details
         app={
           Object {
             "categories": Array [
@@ -1927,7 +1927,7 @@ Gestionnaire de photos pour Cozy v3 :tada:",
         namePrefix="Cozy"
         parent="/myapps"
       />
-      <withClient(withI18n(DetailsWrapper))
+      <Details
         app={
           Object {
             "categories": Array [
@@ -2361,7 +2361,7 @@ Gestionnaire de photos pour Cozy v3 :tada:",
         namePrefix="Cozy"
         parent="/myapps"
       />
-      <withClient(withI18n(DetailsWrapper))
+      <Details
         app={
           Object {
             "categories": Array [

--- a/test/ducks/apps/components/applicationPage/details.spec.js
+++ b/test/ducks/apps/components/applicationPage/details.spec.js
@@ -3,14 +3,19 @@
 /* eslint-env jest */
 
 import React from 'react'
-import { shallow } from 'enzyme'
+import { MemoryRouter } from 'react-router-dom'
+import { render, fireEvent } from '@testing-library/react'
 
-import { tMock } from '../../../../jestLib/I18n'
+import CozyClient, { CozyProvider } from 'cozy-client'
+import I18n from 'cozy-ui/transpiled/react/I18n'
+
 import { Details } from 'ducks/apps/components/ApplicationPage/Details'
-import { REGISTRY_CHANNELS } from 'ducks/apps'
+import { getContext } from 'ducks/apps'
 
 import mockApp from '../../_mockPhotosRegistryVersion'
 import mockKonnector from '../../_mockPKonnectorTrinlaneRegistryVersion'
+
+import enLocale from '../../../../../src/locales/en.json'
 
 jest.mock('assets/icons/platforms/icon-ios.svg', () => {
   return '<svg><text>svg icon</text></svg>'
@@ -20,12 +25,13 @@ jest.mock('assets/icons/platforms/icon-android.svg', () => {
   return '<svg><text>svg icon</text></svg>'
 })
 
+jest.mock('ducks/apps')
+
 const appManifest = mockApp.manifest
 const konnectorManifest = mockKonnector.manifest
 
 const getAppProps = () => {
   return {
-    t: tMock,
     slug: appManifest.slug,
     description: appManifest.locales.en.long_description,
     changes: appManifest.locales.en.changes,
@@ -44,7 +50,6 @@ const getAppProps = () => {
 
 const getKonnectorProps = () => {
   return {
-    t: tMock,
     description: konnectorManifest.locales.en.long_description,
     changes: konnectorManifest.locales.en.changes,
     app: {
@@ -55,19 +60,41 @@ const getKonnectorProps = () => {
   }
 }
 
+const AppLike = ({ children } = {}) => {
+  const mockClient = new CozyClient({})
+
+  return (
+    <MemoryRouter>
+      <CozyProvider client={mockClient}>
+        <I18n lang="en" dictRequire={() => enLocale}>
+          {children}
+        </I18n>
+      </CozyProvider>
+    </MemoryRouter>
+  )
+}
+
 describe('ApplicationPage details component', () => {
   beforeEach(() => {
     jest.resetModules()
   })
 
   it('should be rendered correctly with provided app', () => {
-    const component = shallow(<Details {...getAppProps()} />).getElement()
-    expect(component).toMatchSnapshot()
+    const { container } = render(
+      <AppLike>
+        <Details {...getAppProps()} />
+      </AppLike>
+    )
+    expect(container).toMatchSnapshot()
   })
 
   it('should be rendered correctly with provided konnector', () => {
-    const component = shallow(<Details {...getKonnectorProps()} />).getElement()
-    expect(component).toMatchSnapshot()
+    const { container } = render(
+      <AppLike>
+        <Details {...getKonnectorProps()} />
+      </AppLike>
+    )
+    expect(container).toMatchSnapshot()
   })
 
   it('should be rendered correctly provided app with no description, no platforms, no langs and no changes no version', () => {
@@ -78,116 +105,123 @@ describe('ApplicationPage details component', () => {
     appProps.mobileApps = []
     appProps.developer = {}
     appProps.version = ''
-    const component = shallow(<Details {...appProps} />).getElement()
-    expect(component).toMatchSnapshot()
+    const { container } = render(
+      <AppLike>
+        <Details {...appProps} />
+      </AppLike>
+    )
+    expect(container).toMatchSnapshot()
   })
 
   it('should handle channel switching if with installed app from registry provided', async () => {
-    jest.doMock('ducks/apps', () => ({
-      REGISTRY_CHANNELS,
-      getContext: () =>
-        Promise.resolve({
-          attributes: {
-            debug: true
-          }
-        })
-    }))
-    // we have to re import to handle previous mocking here
-    const MockedDetails = require('ducks/apps/components/ApplicationPage/Details')
-      .Details
+    getContext.mockResolvedValue({
+      attributes: {
+        debug: true
+      }
+    })
     const appProps = getAppProps()
     // correctly handled if from registry and installed
     appProps.app.installed = true
     appProps.app.source = `registry://${appProps}/stable`
-    const component = shallow(<MockedDetails {...appProps} />)
-    await component.instance().toggleChannels()
-    component.update()
-    expect(component.getElement()).toMatchSnapshot()
+    const { container, getByTestId, findByTestId } = render(
+      <AppLike>
+        <Details {...appProps} />
+      </AppLike>
+    )
+
+    const button = getByTestId('toggleChannels')
+
+    fireEvent.dblClick(button)
+    await findByTestId('betaToggle')
+    await findByTestId('devToggle')
+
+    expect(container).toMatchSnapshot()
   })
 
   it('should not suggest Dev channel switching if the context is not in debug mode', async () => {
-    jest.doMock('ducks/apps', () => ({
-      REGISTRY_CHANNELS,
-      getContext: () =>
-        Promise.resolve({
-          attributes: {
-            debug: false
-          }
-        })
-    }))
-    // we have to re import to handle previous mocking here
-    const MockedDetails = require('ducks/apps/components/ApplicationPage/Details')
-      .Details
+    getContext.mockResolvedValue({
+      attributes: {
+        debug: false
+      }
+    })
     const appProps = getAppProps()
     // correctly handled if from registry and installed
     appProps.app.installed = true
     appProps.app.source = `registry://${appProps}/stable`
-    const component = shallow(<MockedDetails {...appProps} />)
-    await component.instance().toggleChannels()
-    component.update()
-    expect(component.getElement()).toMatchSnapshot()
+    const { container, getByTestId, findByTestId } = render(
+      <AppLike>
+        <Details {...appProps} />
+      </AppLike>
+    )
+
+    const button = getByTestId('toggleChannels')
+    fireEvent.dblClick(button)
+
+    await findByTestId('betaToggle')
+
+    expect(container).toMatchSnapshot()
   })
 
   it('should not suggest channel switching if the app is not installed', async () => {
-    jest.doMock('ducks/apps', () => ({
-      REGISTRY_CHANNELS,
-      getContext: () =>
-        Promise.resolve({
-          attributes: {
-            debug: true
-          }
-        })
-    }))
-    // we have to re import to handle previous mocking here
-    const MockedDetails = require('ducks/apps/components/ApplicationPage/Details')
-      .Details
+    getContext.mockResolvedValue({
+      attributes: {
+        debug: true
+      }
+    })
     const appProps = getAppProps()
     appProps.app.installed = false
     appProps.app.source = `registry://${appProps}/stable`
-    const component = shallow(<MockedDetails {...appProps} />)
-    await component.instance().toggleChannels()
-    expect(component.getElement()).toMatchSnapshot()
+    const { container, getByTestId } = render(
+      <AppLike>
+        <Details {...appProps} />
+      </AppLike>
+    )
+
+    const button = getByTestId('toggleChannels')
+    fireEvent.dblClick(button)
+
+    expect(container).toMatchSnapshot()
   })
 
   it('should not suggest channel switching if the installed app is not from registry', async () => {
-    jest.doMock('ducks/apps', () => ({
-      REGISTRY_CHANNELS,
-      getContext: () =>
-        Promise.resolve({
-          attributes: {
-            debug: true
-          }
-        })
-    }))
-    // we have to re import to handle previous mocking here
-    const MockedDetails = require('ducks/apps/components/ApplicationPage/Details')
-      .Details
+    getContext.mockResolvedValue({
+      attributes: {
+        debug: true
+      }
+    })
     const appProps = getAppProps()
     appProps.app.installed = true
     appProps.app.source = `dont://know/source`
-    const component = shallow(<MockedDetails {...appProps} />)
-    await component.instance().toggleChannels()
-    expect(component.getElement()).toMatchSnapshot()
+    const { container, getByTestId } = render(
+      <AppLike>
+        <Details {...appProps} />
+      </AppLike>
+    )
+
+    const button = getByTestId('toggleChannels')
+    fireEvent.dblClick(button)
+
+    expect(container).toMatchSnapshot()
   })
 
   it('should not suggest channel switching if the app is not from registry and not installed', async () => {
-    jest.doMock('ducks/apps', () => ({
-      REGISTRY_CHANNELS,
-      getContext: () =>
-        Promise.resolve({
-          attributes: {
-            debug: true
-          }
-        })
-    }))
-    // we have to re import to handle previous mocking here
-    const MockedDetails = require('ducks/apps/components/ApplicationPage/Details')
-      .Details
+    getContext.mockResolvedValue({
+      attributes: {
+        debug: true
+      }
+    })
     const appProps = getAppProps()
     appProps.app.installed = false
     appProps.app.source = `dont://know/source`
-    const component = shallow(<MockedDetails {...appProps} />)
-    await component.instance().toggleChannels()
-    expect(component.getElement()).toMatchSnapshot()
+    const { container, getByTestId } = render(
+      <AppLike>
+        <Details {...appProps} />
+      </AppLike>
+    )
+
+    const button = getByTestId('toggleChannels')
+    fireEvent.dblClick(button)
+
+    expect(container).toMatchSnapshot()
   })
 })

--- a/test/ducks/apps/components/applicationPage/index.spec.js
+++ b/test/ducks/apps/components/applicationPage/index.spec.js
@@ -155,4 +155,16 @@ describe('ApplicationPage component', () => {
     ).getElement()
     expect(component).toMatchSnapshot()
   })
+
+  it('should put search content on back button URL', () => {
+    const props = getAppProps(true, 'https://photos.mockcozy.cc')
+    const component = shallow(
+      <ApplicationPage
+        t={tMock}
+        {...props}
+        search="type=konnector&category=isp"
+      />
+    ).getElement()
+    expect(component).toMatchSnapshot()
+  })
 })

--- a/test/ducks/apps/components/applicationPage/index.spec.js
+++ b/test/ducks/apps/components/applicationPage/index.spec.js
@@ -34,7 +34,8 @@ const getAppProps = (installed, related, screenshots = []) => {
     lang: 'en',
     mainPageRef: mockRef,
     parent: '/myapps',
-    redirectTo: jest.fn()
+    redirectTo: jest.fn(),
+    search: ''
   }
 }
 
@@ -59,7 +60,8 @@ const getKonnectorProps = (installed, keepDescription = true) => {
       icon: 'https://mockcozy.cc/registry/konnector-trinlane/icon'
     }),
     parent: '/myapps',
-    mainPageRef: mockRef
+    mainPageRef: mockRef,
+    search: ''
   }
 }
 

--- a/test/ducks/apps/components/applicationRouting/__snapshots__/permissionsRoute.spec.js.snap
+++ b/test/ducks/apps/components/applicationRouting/__snapshots__/permissionsRoute.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PermissionsRoute component should display permissions modal if app found 1`] = `
-<withI18n(PermissionsModalWrapper)
+<PermissionsModal
   app={
     Object {
       "categories": Array [

--- a/test/ducks/apps/components/applicationRouting/channelRoute.spec.js
+++ b/test/ducks/apps/components/applicationRouting/channelRoute.spec.js
@@ -20,7 +20,8 @@ const getProps = (isFetching = false, getApp = getAppMock) => ({
 })
 
 jest.mock('react-router-dom', () => ({
-  useParams: jest.fn()
+  useParams: jest.fn(),
+  useLocation: jest.fn()
 }))
 
 describe('ChannelRoute component', () => {

--- a/test/ducks/apps/components/applicationRouting/permissionsRoute.spec.js
+++ b/test/ducks/apps/components/applicationRouting/permissionsRoute.spec.js
@@ -19,7 +19,10 @@ const getProps = (isFetching = false, getApp = getAppMock) => ({
 })
 
 jest.mock('react-router-dom', () => ({
-  useParams: jest.fn()
+  useParams: jest.fn(),
+  useLocation: jest.fn().mockReturnValue({
+    search: ''
+  })
 }))
 
 describe('PermissionsRoute component', () => {

--- a/test/ducks/apps/components/applicationRouting/uninstallRoute.spec.js
+++ b/test/ducks/apps/components/applicationRouting/uninstallRoute.spec.js
@@ -19,7 +19,8 @@ const getProps = (isFetching = false, getApp = getAppMock) => ({
 })
 
 jest.mock('react-router-dom', () => ({
-  useParams: jest.fn()
+  useParams: jest.fn(),
+  useLocation: jest.fn()
 }))
 
 describe('UninstallRoute component', () => {

--- a/test/ducks/apps/components/discover.spec.js
+++ b/test/ducks/apps/components/discover.spec.js
@@ -83,6 +83,20 @@ describe('Discover component', () => {
     expect(mockProps.navigate).toHaveBeenCalledWith(`/discover/collect`)
   })
 
+  it('should transfer search params when navigating to app page', () => {
+    const mockProps = getMockProps()
+    mockProps.searchParams.set('type', 'konnector')
+    mockProps.searchParams.set('category', 'isp')
+    mockProps.searchParams.size = 2 // Bug: URLSearchParams have undefined size when run in tests so we have to enforce it
+    const component = shallow(<Discover t={tMock} {...mockProps} />)
+    const instance = component.instance()
+    instance.onAppClick(mockRegistyApps[0].slug)
+    expect(mockProps.navigate).toHaveBeenCalledTimes(1)
+    expect(mockProps.navigate).toHaveBeenCalledWith(
+      `/discover/collect?type=konnector&category=isp`
+    )
+  })
+
   it('should define the correct onAppClick function to pass to sections with redirectAfterInstall search params, and so replace __APPSLUG__', () => {
     const mockProps = getMockProps()
     mockProps.searchParams.set(

--- a/test/ducks/apps/components/discover.spec.js
+++ b/test/ducks/apps/components/discover.spec.js
@@ -85,16 +85,11 @@ describe('Discover component', () => {
 
   it('should define the correct onAppClick function to pass to sections with redirectAfterInstall search params, and so replace __APPSLUG__', () => {
     const mockProps = getMockProps()
-    const component = shallow(
-      <Discover
-        t={tMock}
-        {...mockProps}
-        searchParams={{
-          get: () =>
-            'http://mespapiers.mycozy.cloud/#/paper/files/energy_invoice/harvest/'
-        }}
-      />
+    mockProps.searchParams.set(
+      'redirectAfterInstall',
+      'http://mespapiers.mycozy.cloud/#/paper/files/energy_invoice/harvest/'
     )
+    const component = shallow(<Discover t={tMock} {...mockProps} />)
     const instance = component.instance()
     instance.onAppClick(mockRegistyApps[0].slug)
     expect(mockProps.navigate).toHaveBeenCalledTimes(1)
@@ -105,15 +100,11 @@ describe('Discover component', () => {
 
   it('should encode uri when using redirectAfterInstall search params', () => {
     const mockProps = getMockProps()
-    const component = shallow(
-      <Discover
-        t={tMock}
-        {...mockProps}
-        searchParams={{
-          get: () => 'http://mydomain/#/paper?param1=val1&param2=val2'
-        }}
-      />
+    mockProps.searchParams.set(
+      'redirectAfterInstall',
+      'http://mydomain/#/paper?param1=val1&param2=val2'
     )
+    const component = shallow(<Discover t={tMock} {...mockProps} />)
     const instance = component.instance()
     instance.onAppClick(mockRegistyApps[0].slug)
     expect(mockProps.navigate).toHaveBeenCalledTimes(1)

--- a/test/ducks/apps/components/discover.spec.js
+++ b/test/ducks/apps/components/discover.spec.js
@@ -31,7 +31,8 @@ const getMockProps = (
   isFetching,
   fetchError,
   actionError: null,
-  navigate: jest.fn()
+  navigate: jest.fn(),
+  searchParams: new URLSearchParams()
 })
 
 describe('Discover component', () => {

--- a/test/ducks/apps/components/myApplications.spec.js
+++ b/test/ducks/apps/components/myApplications.spec.js
@@ -97,4 +97,18 @@ describe('MyApplications component', () => {
     expect(componentMobile.find(BarCenter).length).toBe(1)
     expect(componentMobile.getElement()).toMatchSnapshot()
   })
+
+  it('should transfer search params when navigating to app page', () => {
+    const mockProps = getMockProps()
+    mockProps.searchParams.set('type', 'konnector')
+    mockProps.searchParams.set('category', 'isp')
+    mockProps.searchParams.size = 2 // Bug: URLSearchParams have undefined size when run in tests so we have to enforce it
+    const component = shallow(<MyApplications t={tMock} {...mockProps} />)
+    const instance = component.instance()
+    instance.onAppClick(mockInstalledApps[0].slug)
+    expect(mockProps.navigate).toHaveBeenCalledTimes(1)
+    expect(mockProps.navigate).toHaveBeenCalledWith(
+      `/myapps/collect?type=konnector&category=isp`
+    )
+  })
 })

--- a/test/ducks/apps/components/myApplications.spec.js
+++ b/test/ducks/apps/components/myApplications.spec.js
@@ -28,7 +28,8 @@ const getMockProps = (
   isFetching,
   fetchError,
   actionError: null,
-  navigate: jest.fn()
+  navigate: jest.fn(),
+  searchParams: new URLSearchParams()
 })
 
 describe('MyApplications component', () => {


### PR DESCRIPTION
When navigating from Sections page into Application page we lose the current selected category

This impact is that when we close the Application page using the `BACK TO THE LIST` button, then we cannot display the previously selected section and instead we display the full apps list

Another bug is that the previous search filter and the hide/show apps in maintenance filter are lost

This PR fixes this issue those bugs but also do some refactorings, and fix the Sidebar CSS so menu won't overflow anymore from the sidebar

### Before

When displaying the section page (top), the left menu overflows
The `type=konnector&category=insurance` is lost when navigating to the application page (bottom)
The Sidebar selection is lost when navigating to the application page (bottom)
![image](https://github.com/cozy/cozy-store/assets/1884255/50d1c88e-583f-42f0-b2f4-e3701fcd3bf1)

### After

When displaying the section page (top), the left menu doesn't overflows anymore
The `type=konnector&category=insurance` is kept when navigating to the application page (bottom)
The Sidebar selection is kept when navigating to the application page (bottom)
![image](https://github.com/cozy/cozy-store/assets/1884255/df224517-613b-4a21-88e7-fd83503d40fd)

Also the filter is kept when navigating back to the section page
![image](https://github.com/cozy/cozy-store/assets/1884255/1931af57-f8e0-48f1-bd2f-ebd7ec697c66)


```
### ✨ Features

*

### 🐛 Bug Fixes

* Selected category doesn't overflow anymore from the Sidebar
* Selected category is not lost anymore when selecting an App
* Search filter and other filters are not lost anymore when selecting an App

### 🔧 Tech

*
```
