### PR TITLE
Feat: Update `INSTALL` Intent

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -37,7 +37,9 @@
     {
       "action": "INSTALL",
       "data": [
-        "slug"
+        "slug",
+        "category",
+        "pageToDisplay"
       ],
       "href": "/intents",
       "type": [

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "cozy-logger": "1.9.0",
     "cozy-realtime": "3.14.4",
     "cozy-stack-client": "^40.2.0",
-    "cozy-ui": "^90.7.0",
+    "cozy-ui": "^91.2.0",
     "emoji-js": "3.7.0",
     "focus-trap-react": "4.0.1",
     "fuse.js": "6.5.3",

--- a/src/ducks/apps/components/AppInstallation.jsx
+++ b/src/ducks/apps/components/AppInstallation.jsx
@@ -1,6 +1,6 @@
 import storeConfig from 'config'
 import { APP_TYPE, getAppBySlug, installAppFromRegistry } from 'ducks/apps'
-import { hasPendingUpdate } from 'ducks/apps/appStatus'
+import { hasPendingUpdate, isUnderMaintenance } from 'ducks/apps/appStatus'
 import Partnership from 'ducks/apps/components/Partnership'
 import PermissionsList from 'ducks/apps/components/PermissionsList'
 import ReactMarkdownWrapper from 'ducks/components/ReactMarkdownWrapper'
@@ -90,7 +90,9 @@ export class AppInstallation extends Component {
     const isCurrentAppInstalling = isInstalling === app.slug
     const isTermsReady =
       shouldSkipPermissions(app) || (!app.terms || this.state.isTermsAccepted)
-    return !isCurrentAppInstalling && isTermsReady
+    const underMaintenance = isUnderMaintenance(app)
+
+    return !isCurrentAppInstalling && isTermsReady && !underMaintenance
   }
 
   render() {

--- a/src/ducks/apps/components/ApplicationPage/Details.jsx
+++ b/src/ducks/apps/components/ApplicationPage/Details.jsx
@@ -6,6 +6,7 @@ import Maintenance from 'ducks/apps/components/ApplicationPage/Maintenance'
 import ReactMarkdownWrapper from 'ducks/components/ReactMarkdownWrapper'
 import getChannel from 'lib/getChannelFromSource'
 import { getTranslatedManifestProperty } from 'lib/helpers'
+import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
@@ -209,6 +210,18 @@ export const Details = ({ app, description, changes, parent, mobileApps }) => {
       </div>
     </div>
   )
+}
+
+Details.propTypes = {
+  app: PropTypes.object.isRequired,
+  parent: PropTypes.string.isRequired,
+  changes: PropTypes.string,
+  description: PropTypes.string,
+  intentData: PropTypes.shape({
+    appData: PropTypes.object,
+    data: PropTypes.object
+  }),
+  mobileApps: PropTypes.array
 }
 
 export default Details

--- a/src/ducks/apps/components/ApplicationRouting/PermissionsRoute.jsx
+++ b/src/ducks/apps/components/ApplicationRouting/PermissionsRoute.jsx
@@ -1,4 +1,5 @@
 import PermissionsModal from 'ducks/apps/components/PermissionsModal'
+import IntentPermissionsModal from 'ducks/components/intents/IntentPermissionsModal'
 import React from 'react'
 import { useLocation, useParams } from 'react-router-dom'
 
@@ -6,7 +7,8 @@ export const PermissionsRoute = ({
   getApp,
   isFetching,
   parent,
-  redirectTo
+  redirectTo,
+  intentData
 }) => {
   const params = useParams()
   const { search } = useLocation()
@@ -17,7 +19,9 @@ export const PermissionsRoute = ({
 
   if (!app) return redirectTo(`/${parent}${search}`)
 
-  return <PermissionsModal app={app} parent={`/${parent}`} />
+  const Modal = intentData ? IntentPermissionsModal : PermissionsModal
+
+  return <Modal app={app} parent={`/${parent}`} intentData={intentData} />
 }
 
 export default PermissionsRoute

--- a/src/ducks/apps/components/ApplicationRouting/helpers.js
+++ b/src/ducks/apps/components/ApplicationRouting/helpers.js
@@ -1,0 +1,43 @@
+import { isFlagshipApp } from 'cozy-device-helper'
+
+export const redirectToConfigure = async ({
+  intentData,
+  compose,
+  app,
+  parent,
+  redirectTo,
+  onTerminate
+}) => {
+  const { data } = intentData || {}
+  const enableConfiguration =
+    data && (typeof data.configure === 'undefined' || data.configure)
+
+  const appPath = `/${parent}/${app?.slug || ''}`
+  const configurePath = `${appPath}/configure`
+
+  const redirectToApp = () => redirectTo(appPath)
+
+  if (intentData) {
+    if (enableConfiguration) {
+      /*
+        Within an Intent, we cannot use the `/configure` route, because it ultimately returns the `IntentIframe` component which creates a new `iframe` inside the first one.
+        This results in a `CSP:frame-ancestors` problem
+        It is therefore necessary to favor the use of the `compose` service of `cozy-inter-app` which will add the new `iframe` next to the first
+      */
+      await compose(
+        'CREATE',
+        'io.cozy.accounts',
+        { slug: app.slug }
+      )
+    } else {
+      onTerminate(app)
+    }
+    return
+  }
+
+  if (isFlagshipApp()) {
+    redirectToApp()
+  } else {
+    redirectTo(configurePath)
+  }
+}

--- a/src/ducks/apps/components/ApplicationRouting/helpers.spec.js
+++ b/src/ducks/apps/components/ApplicationRouting/helpers.spec.js
@@ -1,0 +1,96 @@
+import { isFlagshipApp } from 'cozy-device-helper'
+
+import { redirectToConfigure } from './helpers'
+
+jest.mock('cozy-device-helper', () => ({
+  ...jest.requireActual('cozy-device-helper'),
+  isFlagshipApp: jest.fn()
+}))
+
+describe('redirectToConfigure', () => {
+  const parent = 'Parent'
+
+  describe('when intentData is undefined (out of intent)', () => {
+    const intentData = undefined
+    const mockCompose = undefined
+    const mockOnTerminate = undefined
+
+    it('should redirect to the correct path if "isFlagshipApp" is truthy', () => {
+      isFlagshipApp.mockReturnValue(true)
+      const mockRedirectTo = jest.fn()
+      const app = { slug: 'app-slug' }
+
+      redirectToConfigure({
+        intentData,
+        compose: mockCompose,
+        app,
+        parent,
+        redirectTo: mockRedirectTo,
+        onTerminate: mockOnTerminate
+      })
+
+      expect(mockRedirectTo).toHaveBeenCalledWith('/Parent/app-slug')
+    })
+
+    it('should redirect to the correct path if "isFlagshipApp" is falsy', () => {
+      isFlagshipApp.mockReturnValue(false)
+      const mockRedirectTo = jest.fn()
+      const app = { slug: 'app-slug' }
+
+      redirectToConfigure({
+        intentData,
+        compose: mockCompose,
+        app,
+        parent,
+        redirectTo: mockRedirectTo,
+        onTerminate: mockOnTerminate
+      })
+
+      expect(mockRedirectTo).toHaveBeenCalledWith('/Parent/app-slug/configure')
+    })
+  })
+
+  describe('when intentData is defined (in intent)', () => {
+    const mockRedirectTo = jest.fn()
+
+    it('should call to the correct function if "data.configure" is truthy (undefined is considered true)', () => {
+      const intentData = { data: { configure: undefined } }
+      const mockCompose = jest.fn()
+      const mockOnTerminate = jest.fn()
+      const app = { slug: 'app-slug' }
+      redirectToConfigure({
+        intentData,
+        compose: mockCompose,
+        app,
+        parent,
+        redirectTo: mockRedirectTo,
+        onTerminate: mockOnTerminate
+      })
+
+      expect(mockCompose).toHaveBeenCalledWith('CREATE', 'io.cozy.accounts', {
+        slug: 'app-slug'
+      })
+      expect(mockOnTerminate).not.toHaveBeenCalled()
+      expect(mockRedirectTo).not.toHaveBeenCalled()
+    })
+
+    it('should call to the correct function if "data.configure" is false', () => {
+      const intentData = { data: { configure: false } }
+      const mockCompose = jest.fn()
+      const mockOnTerminate = jest.fn()
+      const app = { slug: 'app-slug' }
+      redirectToConfigure({
+        intentData,
+        compose: mockCompose,
+        app,
+        parent,
+        redirectTo: mockRedirectTo,
+        onTerminate: mockOnTerminate
+      })
+
+      expect(mockOnTerminate).toHaveBeenCalledWith({ slug: 'app-slug' })
+      expect(mockCompose).not.toHaveBeenCalled()
+      expect(mockRedirectTo).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/ducks/apps/components/ApplicationRouting/index.jsx
+++ b/src/ducks/apps/components/ApplicationRouting/index.jsx
@@ -4,6 +4,7 @@ import ConfigureRoute from 'ducks/apps/components/ApplicationRouting/ConfigureRo
 import InstallRoute from 'ducks/apps/components/ApplicationRouting/InstallRoute'
 import PermissionsRoute from 'ducks/apps/components/ApplicationRouting/PermissionsRoute'
 import UninstallRoute from 'ducks/apps/components/ApplicationRouting/UninstallRoute'
+import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import {
   Outlet,
@@ -13,14 +14,14 @@ import {
   useNavigate
 } from 'react-router-dom'
 
-import { translate } from 'cozy-ui/transpiled/react/I18n'
-
 const OutletWrapper = ({ Component }) => (
   <>
     <Component />
     <Outlet />
   </>
 )
+
+const intentStyle = { maxHeight: '100%' }
 
 export class ApplicationRouting extends Component {
   mainPage = React.createRef()
@@ -40,9 +41,14 @@ export class ApplicationRouting extends Component {
   }
 
   render() {
-    const { isFetching, parent } = this.props
+    const { isFetching, parent, intentData, onTerminate } = this.props
+
     return (
-      <div className="sto-modal-page" ref={this.mainPage}>
+      <div
+        className="sto-modal-page"
+        style={intentData ? intentStyle : undefined}
+        ref={this.mainPage}
+      >
         <Routes>
           <Route
             path=":appSlug"
@@ -55,6 +61,7 @@ export class ApplicationRouting extends Component {
                     getApp={this.getAppFromMatchOrSlug}
                     redirectTo={this.redirectTo}
                     mainPageRef={this.mainPage}
+                    intentData={intentData}
                   />
                 )}
               />
@@ -79,6 +86,8 @@ export class ApplicationRouting extends Component {
                   isFetching={isFetching}
                   parent={parent}
                   redirectTo={this.redirectTo}
+                  intentData={intentData}
+                  onTerminate={onTerminate}
                 />
               }
             />
@@ -101,6 +110,7 @@ export class ApplicationRouting extends Component {
                   isFetching={isFetching}
                   parent={parent}
                   redirectTo={this.redirectTo}
+                  intentData={intentData}
                 />
               }
             />
@@ -130,4 +140,19 @@ const ApplicationRoutingWrapper = props => {
   )
 }
 
-export default translate()(ApplicationRoutingWrapper)
+ApplicationRoutingWrapper.propTypes = {
+  isAppFetching: PropTypes.bool.isRequired,
+  isFetching: PropTypes.bool.isRequired,
+  parent: PropTypes.string.isRequired,
+  apps: PropTypes.array,
+  actionError: PropTypes.object,
+  installedApps: PropTypes.array,
+  intentData: PropTypes.shape({
+    appData: PropTypes.object,
+    data: PropTypes.object
+  }),
+  isUninstalling: PropTypes.bool,
+  onTerminate: PropTypes.func
+}
+
+export default ApplicationRoutingWrapper

--- a/src/ducks/apps/components/InstallModal.jsx
+++ b/src/ducks/apps/components/InstallModal.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux'
 
 import { withClient } from 'cozy-client'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
+import IntentHeader from 'cozy-ui/transpiled/react/IntentHeader'
 import Portal from 'cozy-ui/transpiled/react/Portal'
 import Modal from 'cozy-ui/transpiled/react/deprecated/Modal'
 
@@ -37,11 +38,23 @@ export class InstallModal extends Component {
   }
 
   render() {
-    const { app, redirectToApp, redirectToConfigure } = this.props
+    const { app, redirectToApp, redirectToConfigure, intentData } = this.props
+    const { appData } = intentData || {}
 
     return (
       <Portal into="body">
-        <Modal dismissAction={this.dismiss} mobileFullscreen>
+        <Modal
+          dismissAction={this.dismiss}
+          mobileFullscreen
+          closable={!intentData}
+        >
+          {intentData && (
+            <IntentHeader
+              appEditor={appData.app.editor}
+              appName={appData.app.name}
+              appIcon={`../${appData.app.icon}`}
+            />
+          )}
           <AppInstallation
             appSlug={app.slug}
             onCancel={this.dismiss}
@@ -59,7 +72,16 @@ InstallModal.propTypes = {
   dismissAction: PropTypes.func.isRequired,
   onInstalled: PropTypes.func.isRequired,
   redirectToConfigure: PropTypes.func.isRequired,
-  redirectToApp: PropTypes.func.isRequired
+  redirectToApp: PropTypes.func.isRequired,
+  intentData: PropTypes.object,
+  /* With Redux */
+  fetchLatestApp: PropTypes.func.isRequired,
+  restoreAppIfSaved: PropTypes.func.isRequired,
+  /* With HOC */
+  client: PropTypes.object.isRequired,
+  f: PropTypes.func.isRequired,
+  lang: PropTypes.string.isRequired,
+  t: PropTypes.func.isRequired
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => ({

--- a/src/ducks/apps/components/QuerystringSections.jsx
+++ b/src/ducks/apps/components/QuerystringSections.jsx
@@ -1,6 +1,7 @@
 import { useNavigateNoUpdates, useLocationNoUpdates } from 'lib/RouterUtils'
 import isNavigationEnabled from 'lib/isNavigationEnabled'
 import omit from 'lodash/omit'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { useMemo } from 'react'
 
@@ -63,6 +64,7 @@ const queryFromFilter = filter => {
  * - handles location updates
  */
 const QuerystringSections = props => {
+  const { intentData } = props
   const navigate = useNavigateNoUpdates()
   const { pathname, search } = useLocationNoUpdates()
 
@@ -71,6 +73,16 @@ const QuerystringSections = props => {
     props.parent,
     search
   ])
+
+  const filterUpdated = useMemo(() => {
+    if (intentData) {
+      return {
+        ...filter,
+        ...(intentData.data?.category && { category: intentData.data.category })
+      }
+    }
+    return filter
+  }, [filter, intentData])
 
   // Saves filter to query part
   const handleFilterChange = filter => {
@@ -86,10 +98,22 @@ const QuerystringSections = props => {
     <Sections
       {...props}
       hasNav={isNavigationEnabled(search)}
-      filter={filter}
+      filter={filterUpdated}
       onFilterChange={handleFilterChange}
+      showFilterDropdown={!intentData}
     />
   )
+}
+
+QuerystringSections.propTypes = {
+  apps: PropTypes.array.isRequired,
+  error: PropTypes.object,
+  intentData: PropTypes.shape({
+    appData: PropTypes.object,
+    data: PropTypes.object
+  }),
+  onAppClick: PropTypes.func.isRequired,
+  parent: PropTypes.string.isRequired
 }
 
 export default QuerystringSections

--- a/src/ducks/apps/components/Sections/Sections.jsx
+++ b/src/ducks/apps/components/Sections/Sections.jsx
@@ -29,7 +29,9 @@ const Sections = ({
   onAppClick,
   filter,
   onFilterChange,
-  parent
+  parent,
+  showFilterDropdown,
+  intentData
 }) => {
   const { lang } = useI18n()
 
@@ -99,6 +101,14 @@ const Sections = ({
 
   if (error) return <p className="u-error">{error.message}</p>
 
+  const componentsProps = {
+    ...(!!intentData && {
+      appsSection: {
+        disableClick: app => app.installed
+      }
+    })
+  }
+
   return (
     <div className="sto-sections u-mt-2">
       <div className="u-flex u-flex-items-center u-mb-1">
@@ -106,7 +116,7 @@ const Sections = ({
           value={searchFieldValue}
           onChange={handleChangeSearchFieldChange}
         />
-        {hasFilters && (
+        {!intentData && hasFilters && (
           <Filters
             filter={filter || internalFilter}
             onFilterChange={handleFilterChange}
@@ -118,9 +128,11 @@ const Sections = ({
       ) : (
         <AppSections
           search={filter}
+          showFilterDropdown={showFilterDropdown}
           onSearchChange={handleFilterChange}
           apps={apps}
           onAppClick={onAppClick}
+          componentsProps={componentsProps}
         />
       )}
     </div>
@@ -130,8 +142,15 @@ const Sections = ({
 Sections.propTypes = {
   apps: PropTypes.array.isRequired,
   error: PropTypes.object,
+  filter: PropTypes.object,
+  intentData: PropTypes.shape({
+    appData: PropTypes.object,
+    data: PropTypes.object
+  }),
   onAppClick: PropTypes.func.isRequired,
-  onFilterChange: PropTypes.func
+  onFilterChange: PropTypes.func,
+  parent: PropTypes.string.isRequired,
+  showFilterDropdown: PropTypes.bool
 }
 
 export default Sections

--- a/src/ducks/components/intents/InstallAppIntent.jsx
+++ b/src/ducks/components/intents/InstallAppIntent.jsx
@@ -2,11 +2,14 @@ import {
   APP_TYPE,
   getAppBySlug,
   installAppFromRegistry,
-  initAppIntent
+  initAppIntent,
+  getRegistryApps,
+  initApp
 } from 'ducks/apps'
-import AppInstallation from 'ducks/apps/components/AppInstallation'
-import InstallSuccess from 'ducks/apps/components/InstallSuccess'
+import InstallAppIntentContent from 'ducks/components/intents/InstallAppIntentContent'
+import { isPermissionsPageToDisplay } from 'ducks/components/intents/helpers'
 import compose from 'lodash/flowRight'
+import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 
@@ -29,7 +32,12 @@ export class InstallAppIntent extends Component {
   }
 
   componentDidMount() {
-    this.props.initAppIntent()
+    const { data } = this.props
+    if (isPermissionsPageToDisplay(data)) {
+      this.props.initAppIntent()
+    } else {
+      this.props.initApp()
+    }
   }
 
   installApp() {
@@ -42,6 +50,11 @@ export class InstallAppIntent extends Component {
   }
 
   async componentDidUpdate(prevProps) {
+    // When the intent should display the page of a connector/app
+    if (this.props.data.slug) {
+      window.location.replace(`#/discover/${this.props.data.slug}`)
+    }
+
     // on install success
     const { hasWebappSucceed, hasKonnectorSucceed } = this.state
     const hasSucceed = hasWebappSucceed || hasKonnectorSucceed
@@ -54,12 +67,16 @@ export class InstallAppIntent extends Component {
       const enableConfiguration =
         data && (typeof data.configure === 'undefined' || data.configure)
 
-      if (app.type === APP_TYPE.KONNECTOR && enableConfiguration) {
-        await compose(
-          'CREATE',
-          'io.cozy.accounts',
-          { slug: app.slug }
-        )
+      if (app.type === APP_TYPE.KONNECTOR) {
+        if (enableConfiguration) {
+          await compose(
+            'CREATE',
+            'io.cozy.accounts',
+            { slug: app.slug }
+          )
+        } else {
+          return this.handleTerminate(app)
+        }
       }
 
       this.onSuccess(enableConfiguration)
@@ -88,22 +105,22 @@ export class InstallAppIntent extends Component {
   render() {
     const {
       app,
+      data,
       appData,
       fetchError,
       installError,
       isFetching,
       isAppFetching,
-      isInstalling,
-      onCancel,
       t
     } = this.props
     const { hasWebappSucceed } = this.state
+    const { category } = data || {}
 
     const fetching = isFetching || isAppFetching
     const isReady = !fetchError && !fetching && !isAppFetching
     const isInstalled = app && app.installed
 
-    const appError = isReady && !app
+    const appError = isReady && !app && !category
     const alreadyInstalledError = !isInstalled && app && app.installed
     const errors = { alreadyInstalledError, fetchError, installError, appError }
     const errorKey = Object.keys(errors).reduce(
@@ -112,6 +129,7 @@ export class InstallAppIntent extends Component {
     )
     const error = !!errorKey && new Error(t(errorKey))
     const isReadyWithoutErrors = isReady && !error
+
     return (
       <div className="coz-intent-wrapper">
         <IntentHeader
@@ -122,23 +140,41 @@ export class InstallAppIntent extends Component {
         <div className={`coz-intent-content${fetching ? ' --loading' : ''}`}>
           {fetching && <Spinner size="xxlarge" noMargin />}
           {error && <div className="coz-error">{error.message}</div>}
-          {isReadyWithoutErrors &&
-            (!isInstalled ? (
-              <AppInstallation
-                appSlug={app.slug}
-                installApp={() => this.installApp()}
-                isInstalling={isInstalling}
-                onCancel={onCancel}
-              />
-            ) : (
-              hasWebappSucceed && (
-                <InstallSuccess app={app} onTerminate={this.handleTerminate} />
-              )
-            ))}
+          {isReadyWithoutErrors && (
+            <InstallAppIntentContent
+              {...this.props}
+              isInstalled={isInstalled}
+              hasWebappSucceed={hasWebappSucceed}
+            />
+          )}
         </div>
       </div>
     )
   }
+}
+
+InstallAppIntent.propTypes = {
+  appData: PropTypes.object.isRequired,
+  onTerminate: PropTypes.func.isRequired,
+  data: PropTypes.object,
+  dismissAction: PropTypes.func,
+  onInstalled: PropTypes.func,
+  redirectToApp: PropTypes.func,
+  redirectToConfigure: PropTypes.func,
+  /* With Redux */
+  initAppIntent: PropTypes.func.isRequired,
+  installApp: PropTypes.func.isRequired,
+  isInstalling: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
+    .isRequired,
+  isFetching: PropTypes.bool.isRequired,
+  isAppFetching: PropTypes.bool.isRequired,
+  app: PropTypes.object,
+  apps: PropTypes.array,
+  fetchError: PropTypes.object,
+  installError: PropTypes.object,
+  /* With HOC */
+  client: PropTypes.object.isRequired,
+  lang: PropTypes.string.isRequired
 }
 
 const mapStateToProps = (state, ownProps) => ({
@@ -147,12 +183,16 @@ const mapStateToProps = (state, ownProps) => ({
   isInstalling: state.apps.isInstalling,
   installError: state.apps.actionError,
   fetchError: state.apps.fetchError,
-  app: getAppBySlug(state, ownProps.data.slug)
+  app: getAppBySlug(state, ownProps.data.slug),
+  apps: getRegistryApps(state)
 })
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
   initAppIntent: () => {
     dispatch(initAppIntent(ownProps.client, ownProps.lang, ownProps.data.slug))
+  },
+  initApp: () => {
+    dispatch(initApp(ownProps.client, ownProps.lang))
   },
   installApp: (app, channel) => dispatch(installAppFromRegistry(app, channel))
 })

--- a/src/ducks/components/intents/InstallAppIntent.jsx
+++ b/src/ducks/components/intents/InstallAppIntent.jsx
@@ -121,8 +121,12 @@ export class InstallAppIntent extends Component {
     const isInstalled = app && app.installed
 
     const appError = isReady && !app && !category
-    const alreadyInstalledError = !isInstalled && app && app.installed
-    const errors = { alreadyInstalledError, fetchError, installError, appError }
+    const errors = {
+      alreadyInstalledError: isInstalled,
+      fetchError,
+      installError,
+      appError
+    }
     const errorKey = Object.keys(errors).reduce(
       (final, key) => (errors[key] ? errorKeys[key] : final),
       null

--- a/src/ducks/components/intents/InstallAppIntentContent.jsx
+++ b/src/ducks/components/intents/InstallAppIntentContent.jsx
@@ -1,0 +1,64 @@
+import AppInstallation from 'ducks/apps/components/AppInstallation'
+import InstallSuccess from 'ducks/apps/components/InstallSuccess'
+import OpenAppsIntentRoutes from 'ducks/components/intents/OpenAppsIntentRoutes'
+import { isPermissionsPageToDisplay } from 'ducks/components/intents/helpers'
+import PropTypes from 'prop-types'
+import React from 'react'
+import { HashRouter } from 'react-router-dom'
+
+const InstallAppIntentContent = ({
+  data,
+  isInstalled,
+  app,
+  appData,
+  installApp,
+  hasWebappSucceed,
+  isInstalling,
+  onCancel,
+  onTerminate,
+  compose
+}) => {
+  const intentData = { data, appData, serviceCompose: compose }
+
+  if (!isInstalled) {
+    if (isPermissionsPageToDisplay(data)) {
+      return (
+        <AppInstallation
+          appSlug={app.slug}
+          installApp={installApp}
+          isInstalling={isInstalling}
+          onCancel={onCancel}
+        />
+      )
+    }
+    return (
+      <HashRouter>
+        <OpenAppsIntentRoutes
+          intentData={intentData}
+          onTerminate={onTerminate}
+        />
+      </HashRouter>
+    )
+  }
+
+  if (hasWebappSucceed) {
+    return <InstallSuccess app={app} onTerminate={onTerminate} />
+  }
+
+  return null
+}
+
+InstallAppIntentContent.propTypes = {
+  appData: PropTypes.object.isRequired,
+  data: PropTypes.object.isRequired,
+  hasWebappSucceed: PropTypes.bool.isRequired,
+  installApp: PropTypes.func.isRequired,
+  isInstalling: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
+    .isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onTerminate: PropTypes.func.isRequired,
+  app: PropTypes.object,
+  isInstalled: PropTypes.bool
+}
+
+export default InstallAppIntentContent

--- a/src/ducks/components/intents/IntentPermissionsModal.jsx
+++ b/src/ducks/components/intents/IntentPermissionsModal.jsx
@@ -1,0 +1,45 @@
+import PermissionsList from 'ducks/apps/components/PermissionsList'
+import React from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Left from 'cozy-ui/transpiled/react/Icons/Left'
+import IntentHeader from 'cozy-ui/transpiled/react/IntentHeader'
+import Portal from 'cozy-ui/transpiled/react/Portal'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import Button from 'cozy-ui/transpiled/react/deprecated/Button'
+import Modal, { ModalContent } from 'cozy-ui/transpiled/react/deprecated/Modal'
+
+export const IntentPermissionsModal = ({ app, parent, intentData }) => {
+  const { appData } = intentData || {}
+  const { t } = useI18n()
+  const navigate = useNavigate()
+  const { search } = useLocation()
+
+  return (
+    <Portal into="body">
+      <Modal mobileFullscreen closable={false}>
+        <IntentHeader
+          appEditor={appData.app.editor}
+          appName={appData.app.name}
+          appIcon={`../${appData.app.icon}`}
+        />
+        <ModalContent>
+          <Button
+            icon={Left}
+            className="sto-app-back"
+            label={t('app_modal.permissions.back')}
+            onClick={() => navigate(`${parent}/${app.slug}${search}`)}
+            subtle
+          />
+          <Typography variant="h5" className="u-ta-center">
+            {t('app_modal.permissions.title')}
+          </Typography>
+          <PermissionsList app={app} />
+        </ModalContent>
+      </Modal>
+    </Portal>
+  )
+}
+
+export default IntentPermissionsModal

--- a/src/ducks/components/intents/OpenAppsIntentRoutes.jsx
+++ b/src/ducks/components/intents/OpenAppsIntentRoutes.jsx
@@ -1,0 +1,26 @@
+import { Discover } from 'ducks/apps/Containers'
+import PropTypes from 'prop-types'
+import React from 'react'
+import { Navigate, Route, Routes } from 'react-router-dom'
+
+const OpenAppsIntentRoutes = ({ intentData, onTerminate }) => {
+  return (
+    <Routes>
+      <Route
+        path="discover/*"
+        element={<Discover intentData={intentData} onTerminate={onTerminate} />}
+      />
+      <Route path="*" element={<Navigate replace to="discover" />} />
+    </Routes>
+  )
+}
+
+OpenAppsIntentRoutes.propTypes = {
+  intentData: PropTypes.shape({
+    appData: PropTypes.object,
+    data: PropTypes.object
+  }).isRequired,
+  onTerminate: PropTypes.func.isRequired
+}
+
+export default OpenAppsIntentRoutes

--- a/src/ducks/components/intents/helpers.js
+++ b/src/ducks/components/intents/helpers.js
@@ -1,0 +1,4 @@
+export const isPermissionsPageToDisplay = data => {
+  const { pageToDisplay, category } = data || {}
+  return !category && (!pageToDisplay || pageToDisplay === 'permissions')
+}

--- a/src/ducks/components/intents/helpers.spec.js
+++ b/src/ducks/components/intents/helpers.spec.js
@@ -1,0 +1,15 @@
+import { isPermissionsPageToDisplay } from 'ducks/components/intents/helpers'
+
+describe('isPermissionsPageToDisplay', () => {
+  it.each`
+    data                                                     | result
+    ${undefined}                                             | ${true}
+    ${{ pageToDisplay: undefined, category: undefined }}     | ${true}
+    ${{ pageToDisplay: 'permissions', category: undefined }} | ${true}
+    ${{ pageToDisplay: undefined, category: 'energy' }}      | ${false}
+    ${{ pageToDisplay: 'details', category: 'energy' }}      | ${false}
+    ${{ pageToDisplay: 'permissions', category: 'energy' }}  | ${false}
+  `(`should return $result when passed param: $data`, ({ data, result }) => {
+    expect(isPermissionsPageToDisplay(data)).toEqual(result)
+  })
+})

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -69,7 +69,8 @@
       }
     },
     "permissions": {
-      "title": "Permissions"
+      "title": "Permissions",
+      "back": "Back"
     }
   },
 

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -69,7 +69,8 @@
       }
     },
     "permissions": {
-      "title": "Permissions"
+      "title": "Permissions",
+      "back": "Retour"
     }
   },
 

--- a/src/targets/intents/index.jsx
+++ b/src/targets/intents/index.jsx
@@ -1,16 +1,20 @@
+/* eslint-disable import/order */
+import 'cozy-ui/dist/cozy-ui.utils.min.css'
+import 'cozy-ui/transpiled/react/stylesheet.css'
+import 'styles'
+
+import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import InstallAppIntent from 'ducks/components/intents/InstallAppIntent'
+import IntentHandler from 'ducks/components/intents/IntentHandler'
 import schema from 'lib/schema'
 import store from 'lib/store'
 import React from 'react'
 import { render } from 'react-dom'
 import { Provider } from 'react-redux'
-import 'styles'
 
 import CozyClient, { CozyProvider } from 'cozy-client'
 import flag from 'cozy-flags'
 import I18n from 'cozy-ui/transpiled/react/I18n'
-
-import InstallAppIntent from '../../ducks/components/intents/InstallAppIntent'
-import IntentHandler from '../../ducks/components/intents/IntentHandler'
 
 document.addEventListener('DOMContentLoaded', () => {
   const root = document.querySelector('[role=application]')
@@ -32,9 +36,11 @@ document.addEventListener('DOMContentLoaded', () => {
     >
       <CozyProvider store={store} client={client}>
         <Provider store={store}>
-          <IntentHandler appData={appData}>
-            <InstallAppIntent action="INSTALL" type="io.cozy.apps" />
-          </IntentHandler>
+          <BreakpointsProvider>
+            <IntentHandler appData={appData}>
+              <InstallAppIntent action="INSTALL" type="io.cozy.apps" />
+            </IntentHandler>
+          </BreakpointsProvider>
         </Provider>
       </CozyProvider>
     </I18n>,

--- a/test/components/intents/InstallAppIntentContent.spec.js
+++ b/test/components/intents/InstallAppIntentContent.spec.js
@@ -1,0 +1,123 @@
+import '@testing-library/jest-dom'
+import { render } from '@testing-library/react'
+import InstallAppIntentContent from 'ducks/components/intents/InstallAppIntentContent'
+import React from 'react'
+
+import CozyClient, { CozyProvider } from 'cozy-client'
+import I18n from 'cozy-ui/transpiled/react/I18n'
+
+import enLocale from '../../../src/locales/en.json'
+
+jest.mock('ducks/components/intents/OpenAppsIntentRoutes', () => () => (
+  <div data-testid="OpenAppsIntentRoutes" />
+))
+jest.mock('ducks/apps/components/AppInstallation', () => () => (
+  <div data-testid="AppInstallation" />
+))
+jest.mock('ducks/apps/components/InstallSuccess', () => () => (
+  <div data-testid="InstallSuccess" />
+))
+
+const AppLike = ({ children } = {}) => {
+  const mockClient = new CozyClient({})
+
+  return (
+    <CozyProvider client={mockClient}>
+      <I18n lang="en" dictRequire={() => enLocale}>
+        {children}
+      </I18n>
+    </CozyProvider>
+  )
+}
+
+const setup = ({
+  slug = undefined,
+  category = undefined,
+  pageToDisplay = undefined,
+  isInstalled = false,
+  hasWebappSucceed = false
+} = {}) => {
+  const data = { pageToDisplay, category, slug }
+  const props = {
+    data,
+    isInstalled,
+    app: {},
+    appData: {},
+    installApp: jest.fn(),
+    hasWebappSucceed,
+    isInstalling: '',
+    onCancel: jest.fn(),
+    onTerminate: jest.fn()
+  }
+
+  return render(
+    <AppLike>
+      <InstallAppIntentContent {...props} />
+    </AppLike>
+  )
+}
+
+describe('InstallAppIntentContent component', () => {
+  describe('App is installed', () => {
+    it('should be render null if "hasWebappSucceed" prop is falsy', () => {
+      const { queryByTestId } = setup({
+        isInstalled: true,
+        hasWebappSucceed: false
+      })
+      expect(queryByTestId('AppInstallation')).toBeNull()
+      expect(queryByTestId('OpenAppsIntentRoutes')).toBeNull()
+      expect(queryByTestId('InstallSuccess')).toBeNull()
+    })
+    it('should be render null if "hasWebappSucceed" prop is truthy', () => {
+      const { getByTestId, queryByTestId } = setup({
+        isInstalled: true,
+        hasWebappSucceed: true
+      })
+      expect(getByTestId('InstallSuccess')).toBeInTheDocument()
+      expect(queryByTestId('AppInstallation')).toBeNull()
+      expect(queryByTestId('OpenAppsIntentRoutes')).toBeNull()
+    })
+  })
+
+  describe('App is not installed', () => {
+    it('should be render AppInstallation if "pageToDisplay" & "category" props are falsy', () => {
+      const { getByTestId, queryByTestId } = setup({
+        pageToDisplay: undefined,
+        category: undefined
+      })
+      expect(getByTestId('AppInstallation')).toBeInTheDocument()
+      expect(queryByTestId('OpenAppsIntentRoutes')).toBeNull()
+      expect(queryByTestId('InstallSuccess')).toBeNull()
+    })
+
+    it('should be render OpenAppsIntentRoutes if "pageToDisplay" prop is defined & not equal to "permissions"', () => {
+      const { getByTestId, queryByTestId } = setup({
+        pageToDisplay: 'details',
+        category: undefined
+      })
+      expect(getByTestId('OpenAppsIntentRoutes')).toBeInTheDocument()
+      expect(queryByTestId('AppInstallation')).toBeNull()
+      expect(queryByTestId('InstallSuccess')).toBeNull()
+    })
+
+    it('should be render OpenAppsIntentRoutes if "category" prop is truthy even if "pageToDisplay" is undefined', () => {
+      const { getByTestId, queryByTestId } = setup({
+        pageToDisplay: undefined,
+        category: 'energy'
+      })
+      expect(getByTestId('OpenAppsIntentRoutes')).toBeInTheDocument()
+      expect(queryByTestId('AppInstallation')).toBeNull()
+      expect(queryByTestId('InstallSuccess')).toBeNull()
+    })
+
+    it('should be render OpenAppsIntentRoutes if "category" prop is truthy even if "pageToDisplay" is et to "permission"', () => {
+      const { getByTestId, queryByTestId } = setup({
+        pageToDisplay: 'permissions',
+        category: 'energy'
+      })
+      expect(getByTestId('OpenAppsIntentRoutes')).toBeInTheDocument()
+      expect(queryByTestId('AppInstallation')).toBeNull()
+      expect(queryByTestId('InstallSuccess')).toBeNull()
+    })
+  })
+})

--- a/test/components/intents/__snapshots__/installAppIntent.spec.js.snap
+++ b/test/components/intents/__snapshots__/installAppIntent.spec.js.snap
@@ -12,9 +12,35 @@ exports[`InstallAppIntent component should be rendered correctly 1`] = `
   <div
     className="coz-intent-content"
   >
-    <withClient(Connect(withI18n(AppInstallation)))
-      appSlug="drive"
-      installApp={[Function]}
+    <InstallAppIntentContent
+      app={
+        Object {
+          "slug": "drive",
+        }
+      }
+      appData={
+        Object {
+          "app": Object {
+            "editor": "Cozy",
+            "icon": "/path/to/icon",
+            "name": "Drive",
+          },
+        }
+      }
+      hasWebappSucceed={false}
+      initAppIntent={
+        [MockFunction] {
+          "calls": Array [
+            Array [],
+          ],
+          "results": Array [
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        }
+      }
     />
   </div>
 </div>

--- a/test/ducks/apps/components/__snapshots__/discover.spec.js.snap
+++ b/test/ducks/apps/components/__snapshots__/discover.spec.js.snap
@@ -190,7 +190,7 @@ exports[`Discover component should be rendered correctly with apps 1`] = `
     </div>
     <withI18n(AppVote) />
   </div>
-  <withI18n(ApplicationRoutingWrapper)
+  <ApplicationRoutingWrapper
     actionError={null}
     apps={
       Array [
@@ -560,7 +560,7 @@ exports[`Discover component should be rendered correctly with apps and URL searc
     </div>
     <withI18n(AppVote) />
   </div>
-  <withI18n(ApplicationRoutingWrapper)
+  <ApplicationRoutingWrapper
     actionError={null}
     apps={
       Array [
@@ -759,7 +759,7 @@ exports[`Discover component should display error from props correctly 1`] = `
     </div>
     <withI18n(AppVote) />
   </div>
-  <withI18n(ApplicationRoutingWrapper)
+  <ApplicationRoutingWrapper
     actionError={null}
     apps={Array []}
     isFetching={false}
@@ -779,7 +779,7 @@ exports[`Discover component should render correctly a spinner if apps is fetchin
       className="sto-discover-sections"
     />
   </div>
-  <withI18n(ApplicationRoutingWrapper)
+  <ApplicationRoutingWrapper
     actionError={null}
     apps={Array []}
     isFetching={true}
@@ -985,7 +985,7 @@ exports[`Discover component should use BarCenter from cozy-bar in mobile view on
     </div>
     <withI18n(AppVote) />
   </div>
-  <withI18n(ApplicationRoutingWrapper)
+  <ApplicationRoutingWrapper
     actionError={null}
     apps={
       Array [

--- a/test/ducks/apps/components/__snapshots__/myApplications.spec.js.snap
+++ b/test/ducks/apps/components/__snapshots__/myApplications.spec.js.snap
@@ -155,7 +155,7 @@ exports[`MyApplications component should be rendered correctly if apps uninstall
       parent="myapps"
     />
   </div>
-  <withI18n(ApplicationRoutingWrapper)
+  <ApplicationRoutingWrapper
     actionError={null}
     installedApps={
       Array [
@@ -460,7 +460,7 @@ exports[`MyApplications component should be rendered correctly with apps and URL
       parent="myapps"
     />
   </div>
-  <withI18n(ApplicationRoutingWrapper)
+  <ApplicationRoutingWrapper
     actionError={null}
     installedApps={
       Array [
@@ -624,7 +624,7 @@ exports[`MyApplications component should display error from props correctly 1`] 
       parent="myapps"
     />
   </div>
-  <withI18n(ApplicationRoutingWrapper)
+  <ApplicationRoutingWrapper
     actionError={null}
     installedApps={Array []}
     isFetching={false}
@@ -640,7 +640,7 @@ exports[`MyApplications component should render correctly a spinner if apps is f
   <div
     className="sto-list-container"
   />
-  <withI18n(ApplicationRoutingWrapper)
+  <ApplicationRoutingWrapper
     actionError={null}
     installedApps={Array []}
     isFetching={true}
@@ -811,7 +811,7 @@ exports[`MyApplications component should use BarCenter from cozy-bar in mobile v
       parent="myapps"
     />
   </div>
-  <withI18n(ApplicationRoutingWrapper)
+  <ApplicationRoutingWrapper
     actionError={null}
     installedApps={
       Array [

--- a/test/ducks/apps/components/applicationPage/__snapshots__/details.spec.js.snap
+++ b/test/ducks/apps/components/applicationPage/__snapshots__/details.spec.js.snap
@@ -400,6 +400,107 @@ exports[`ApplicationPage details component should be rendered correctly with pro
 </div>
 `;
 
+exports[`ApplicationPage details component should be rendered correctly with provided konnector in Intent 1`] = `
+<div>
+  <div
+    class="sto-app-details"
+  >
+    <div
+      class="sto-app-descriptions"
+    />
+    <div
+      class="sto-app-additional-details"
+    >
+      <h3
+        class="u-title-h3"
+      >
+        Informations
+      </h3>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Categories
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          Transportation
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Version
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          <span
+            data-testid="toggleChannels"
+          >
+            Unknown
+          </span>
+        </div>
+      </div>
+      <div
+        class="sto-app-info"
+      >
+        <div
+          class="sto-app-info-header"
+        >
+          Languages
+        </div>
+        <div
+          class="sto-app-info-content"
+        >
+          French, English
+        </div>
+      </div>
+      <div>
+        <button
+          class="styles__c-btn___3kXsk styles__c-btn--subtle___2rRQ0 styles__c-btn--center___Nny0n sto-app-permissions-button"
+          type="submit"
+        >
+          <span>
+            <span>
+              Show permissions
+            </span>
+          </span>
+        </button>
+      </div>
+      <div>
+        <h3
+          class="u-title-h3"
+        >
+          Developer Details
+        </h3>
+        <div
+          class="sto-app-developer-infos"
+        >
+          <span>
+            Cozy
+          </span>
+          <a
+            class="sto-app-developer-link"
+            href="https://cozy.io"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            https://cozy.io
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`ApplicationPage details component should handle channel switching if with installed app from registry provided 1`] = `
 <div>
   <div

--- a/test/ducks/apps/components/applicationPage/details.spec.js
+++ b/test/ducks/apps/components/applicationPage/details.spec.js
@@ -46,7 +46,7 @@ const getAppProps = () => {
   }
 }
 
-const getKonnectorProps = () => {
+const getKonnectorProps = ({ withIntent } = {}) => {
   return {
     description: konnectorManifest.locales.en.long_description,
     changes: konnectorManifest.locales.en.changes,
@@ -54,7 +54,16 @@ const getKonnectorProps = () => {
       categories: konnectorManifest.categories,
       langs: konnectorManifest.langs,
       developer: konnectorManifest.developer
-    }
+    },
+    ...(withIntent && {
+      intentData: {
+        data: {
+          slug: 'slug',
+          category: 'category'
+        },
+        appData: {}
+      }
+    })
   }
 }
 
@@ -90,6 +99,15 @@ describe('ApplicationPage details component', () => {
     const { container } = render(
       <AppLike>
         <Details {...getKonnectorProps()} />
+      </AppLike>
+    )
+    expect(container).toMatchSnapshot()
+  })
+
+  it('should be rendered correctly with provided konnector in Intent', () => {
+    const { container } = render(
+      <AppLike>
+        <Details {...getKonnectorProps({ withIntent: true })} />
       </AppLike>
     )
     expect(container).toMatchSnapshot()

--- a/test/ducks/apps/components/applicationPage/index.spec.js
+++ b/test/ducks/apps/components/applicationPage/index.spec.js
@@ -35,7 +35,8 @@ const getAppProps = (installed, related, screenshots = []) => {
     mainPageRef: mockRef,
     parent: '/myapps',
     redirectTo: jest.fn(),
-    search: ''
+    search: '',
+    breakpoints: {}
   }
 }
 
@@ -61,7 +62,8 @@ const getKonnectorProps = (installed, keepDescription = true) => {
     }),
     parent: '/myapps',
     mainPageRef: mockRef,
-    search: ''
+    search: '',
+    breakpoints: {}
   }
 }
 

--- a/test/ducks/apps/components/discover.spec.js
+++ b/test/ducks/apps/components/discover.spec.js
@@ -95,36 +95,6 @@ describe('Discover component', () => {
     )
   })
 
-  it('should define the correct onAppClick function to pass to sections with redirectAfterInstall search params, and so replace __APPSLUG__', () => {
-    const mockProps = getMockProps()
-    mockProps.searchParams.set(
-      'redirectAfterInstall',
-      'http://mespapiers.mycozy.cloud/#/paper/files/energy_invoice/harvest/'
-    )
-    const component = shallow(<Discover t={tMock} {...mockProps} />)
-    const instance = component.instance()
-    instance.onAppClick(mockRegistyApps[0].slug)
-    expect(mockProps.navigate).toHaveBeenCalledTimes(1)
-    expect(mockProps.navigate).toHaveBeenCalledWith(
-      `/discover/collect?redirectAfterInstall=http%3A%2F%2Fmespapiers.mycozy.cloud%2F%23%2Fpaper%2Ffiles%2Fenergy_invoice%2Fharvest%2F%3FconnectorSlug%3Dcollect`
-    )
-  })
-
-  it('should encode uri when using redirectAfterInstall search params', () => {
-    const mockProps = getMockProps()
-    mockProps.searchParams.set(
-      'redirectAfterInstall',
-      'http://mydomain/#/paper?param1=val1&param2=val2'
-    )
-    const component = shallow(<Discover t={tMock} {...mockProps} />)
-    const instance = component.instance()
-    instance.onAppClick(mockRegistyApps[0].slug)
-    expect(mockProps.navigate).toHaveBeenCalledTimes(1)
-    expect(mockProps.navigate).toHaveBeenCalledWith(
-      `/discover/collect?redirectAfterInstall=http%3A%2F%2Fmydomain%2F%23%2Fpaper%3Fparam1%3Dval1%26param2%3Dval2%3FconnectorSlug%3Dcollect`
-    )
-  })
-
   it('should use BarCenter from cozy-bar in mobile view only', () => {
     const mockProps = getMockProps()
     const component = shallow(<Discover t={tMock} {...mockProps} />)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5606,10 +5606,10 @@ cozy-ui@22.3.1:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
-cozy-ui@^90.7.0:
-  version "90.7.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-90.7.0.tgz#180436f4b13f2339eb11b73e73bc7816042a3874"
-  integrity sha512-p1labaBMiY+zQ4R2rgX3RFedltwfVTp2l/c/DUl5uhtOkVXybzsIsgDJnZwJGHkoCbccY2S9bPDmQ47z7NubJw==
+cozy-ui@^91.2.0:
+  version "91.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-91.2.0.tgz#26562c02bcc7f0679fa668651a2185351d0f0ca9"
+  integrity sha512-zOMf68tGZNmABcxRoNrfJ7MOnaS8g1V+zGgwm9fhKhU/jolE/nDFKmsC6rmCeymwU3ubkujBHXGRyNn4W5tvhg==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"


### PR DESCRIPTION
This Intent can now redirect to 2 additional pages.
With the `category` option, we display the page of konnectors/apps filtered by category.
With the `slug` and `activateDescriptionPageForSlug` option, we display the description page of the konnector/app.
With only the `slug`, cozy-store always shows the permissions page

The code around the `redirectAfterInstall` searchparams is no longer useful and can therefore be removed.

The rest of the process remains essentially identical to the Intent `InstallAppIntent`(`INSTALL`)

- [x] Merge after: https://github.com/cozy/cozy-ui/pull/2492

```
### ✨ Features

* Update `INSTALL` Intent, this Intent can now redirect to 2 additional pages, with `activateDescriptionPageForSlug` & `category` option.
  In the case of a `slug` with `activateDescriptionPageForSlug` are defined, this Intent opens cozy-store on the konnector/app details page, instead of the permissions page.
```
