### PR TITLE
fix: Don't call cozy.bar outside of the React Tree

### DIFF
--- a/src/ducks/apps/components/ApplicationPage/index.jsx
+++ b/src/ducks/apps/components/ApplicationPage/index.jsx
@@ -27,9 +27,6 @@ const MOBILE_PLATFORMS = ['ios', 'android']
 const isMobilePlatform = name => MOBILE_PLATFORMS.includes(name)
 const intentStyle = { marginTop: '1.5rem' }
 
-// In case we are in an Intent, `cozy.bar` is undefined and it's not a big deal since we don't need the cozy-bar to be displayed on an intent
-const { BarCenter } = cozy.bar || {}
-
 export class ApplicationPage extends Component {
   constructor(props) {
     super(props)
@@ -91,6 +88,8 @@ export class ApplicationPage extends Component {
       client,
       intentData
     } = this.props
+    // In case we are in an Intent, `cozy.bar` is undefined and it's not a big deal since we don't need the cozy-bar to be displayed on an intent
+    const { BarCenter } = cozy.bar || {}
     if (isFetching) return <ApplicationPageLoading />
     const app = getApp(params)
     if (!app) return redirectTo(`/${parent}`)

--- a/src/ducks/apps/components/Discover.jsx
+++ b/src/ducks/apps/components/Discover.jsx
@@ -12,9 +12,6 @@ import { translate } from 'cozy-ui/transpiled/react/I18n'
 import { Content } from 'cozy-ui/transpiled/react/Layout'
 import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
 
-// In case we are in an Intent, `cozy.bar` is undefined and it's not a big deal since we don't need the cozy-bar to be displayed on an intent
-const { BarCenter } = cozy.bar || {}
-
 export class Discover extends Component {
   constructor(props) {
     super(props)
@@ -44,6 +41,9 @@ export class Discover extends Component {
 
     const { isMobile } = breakpoints
     const title = <h2 className="sto-view-title">{t('discover.title')}</h2>
+
+    // In case we are in an Intent, `cozy.bar` is undefined and it's not a big deal since we don't need the cozy-bar to be displayed on an intent
+    const { BarCenter } = cozy.bar || {}
 
     return (
       <Content className="sto-discover">

--- a/src/ducks/apps/components/MyApplications.jsx
+++ b/src/ducks/apps/components/MyApplications.jsx
@@ -10,8 +10,6 @@ import { translate } from 'cozy-ui/transpiled/react/I18n'
 import { Content } from 'cozy-ui/transpiled/react/Layout'
 import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
 
-const { BarCenter } = cozy.bar
-
 export class MyApplications extends Component {
   constructor(props) {
     super(props)
@@ -37,6 +35,8 @@ export class MyApplications extends Component {
       isExact
     } = this.props
     const { isMobile } = breakpoints
+    const { BarCenter } = cozy.bar
+
     const title = <h2 className="sto-view-title">{t('myapps.title')}</h2>
     return (
       <Content className="sto-myapps">

--- a/src/ducks/apps/components/Sections/components/Filters.jsx
+++ b/src/ducks/apps/components/Sections/components/Filters.jsx
@@ -12,8 +12,6 @@ import ActionMenu, {
 } from 'cozy-ui/transpiled/react/deprecated/ActionMenu'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
-const { BarRight } = cozy.bar
-
 const Filters = ({ filter, onFilterChange }) => {
   const anchorRef = useRef()
   const [menuDisplayed, setMenuDisplayed] = useState(false)
@@ -46,6 +44,7 @@ const Filters = ({ filter, onFilterChange }) => {
 
   const { isMobile } = useBreakpoints()
   const { t } = useI18n()
+  const { BarRight } = cozy.bar
 
   return (
     <>


### PR DESCRIPTION
In a few scenarios, we don't inject the cozy.bar object to the react tree. This is the case for the Intent use case. Since we don't display the cozy-bar, we don't inject it in order to have a smaller bundle.

And within the code, if a component need the cozy.bar to be displayed and if it's called within an intent, then we polyfil the global var.

But since the destructuring object was done at the build / import phase and not during the component lifecycle, we got an error telling that we can't reader BarRight from undefined, even if the component was not displayed.

So to fix that, we should only call cozy.bar within the component lifecycle.

