### PR TITLE
feat(Intent): Add `terminateIfInstalled` option to intentData

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -39,7 +39,8 @@
       "data": [
         "slug",
         "category",
-        "pageToDisplay"
+        "pageToDisplay",
+        "terminateIfInstalled"
       ],
       "href": "/intents",
       "type": [

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "cozy-intent": "^2.0.2",
     "cozy-interapp": "0.9.0",
     "cozy-logger": "1.9.0",
+    "cozy-minilog": "^3.3.1",
     "cozy-realtime": "3.14.4",
     "cozy-stack-client": "^41.2.0",
     "cozy-ui": "^95.8.0",

--- a/src/ducks/apps/components/ApplicationPage/Header.jsx
+++ b/src/ducks/apps/components/ApplicationPage/Header.jsx
@@ -14,14 +14,12 @@ import { Link, useLocation } from 'react-router-dom'
 import { withClient } from 'cozy-client'
 import { isFlagshipApp } from 'cozy-device-helper'
 import { useWebviewIntent } from 'cozy-intent'
-import Intents from 'cozy-interapp'
-import minilog from 'cozy-minilog'
 import AppIcon from 'cozy-ui/transpiled/react/AppIcon'
 import Button from 'cozy-ui/transpiled/react/deprecated/Button'
 import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
 import { translate } from 'cozy-ui/transpiled/react/providers/I18n'
 
-const log = minilog('Header')
+import { handleIntent } from './helpers'
 
 export const Header = ({
   t,
@@ -49,23 +47,7 @@ export const Header = ({
     if (isFlagshipApp()) {
       return webviewIntent.call('openApp', app.related, app)
     } else {
-      const intents = new Intents({ client })
-      // `intents.createService` throw an error if executed outside of an Intent iframe or if it is called without intentId.
-      if (intentData) {
-        try {
-          const service = await intents.createService()
-
-          if (intentData.data.terminateIfInstalled) {
-            return service.terminate(app)
-          }
-        } catch (error) {
-          log.error('Error on openConnector', error)
-        }
-      }
-
-      return intents.redirect('io.cozy.accounts', {
-        konnector: app.slug
-      })
+      handleIntent(client, intentData, app)
     }
   }
 

--- a/src/ducks/apps/components/ApplicationPage/Header.jsx
+++ b/src/ducks/apps/components/ApplicationPage/Header.jsx
@@ -15,11 +15,13 @@ import { withClient } from 'cozy-client'
 import { isFlagshipApp } from 'cozy-device-helper'
 import { useWebviewIntent } from 'cozy-intent'
 import Intents from 'cozy-interapp'
-import log from 'cozy-logger'
+import minilog from 'cozy-minilog'
 import AppIcon from 'cozy-ui/transpiled/react/AppIcon'
 import Button from 'cozy-ui/transpiled/react/deprecated/Button'
 import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
 import { translate } from 'cozy-ui/transpiled/react/providers/I18n'
+
+const log = minilog('Header')
 
 export const Header = ({
   t,
@@ -57,7 +59,7 @@ export const Header = ({
             return service.terminate(app)
           }
         } catch (error) {
-          log('info', error, 'openConnector')
+          log.error('Error on openConnector', error)
         }
       }
 

--- a/src/ducks/apps/components/ApplicationPage/helpers.js
+++ b/src/ducks/apps/components/ApplicationPage/helpers.js
@@ -1,0 +1,29 @@
+import Intents from 'cozy-interapp'
+import minilog from 'cozy-minilog'
+
+const log = minilog('Header')
+
+/**
+ * @param {import('cozy-client/types/CozyClient').default} client
+ * @param {object} intentData
+ * @param {object} app
+ */
+export const handleIntent = async (client, intentData, app) => {
+  const intents = new Intents({ client })
+  // `intents.createService` throw an error if executed outside of an Intent iframe or if it is called without intentId.
+  if (intentData) {
+    try {
+      const service = await intents.createService()
+
+      if (intentData.data.terminateIfInstalled) {
+        return service.terminate(app)
+      }
+    } catch (error) {
+      log.error('Error on openConnector', error)
+    }
+  }
+
+  return intents.redirect('io.cozy.accounts', {
+    konnector: app.slug
+  })
+}

--- a/src/ducks/apps/components/ApplicationPage/helpers.spec.js
+++ b/src/ducks/apps/components/ApplicationPage/helpers.spec.js
@@ -1,0 +1,51 @@
+import { handleIntent } from './helpers'
+
+const mockIntentCreateServiceTerminate = jest.fn()
+const mockIntentCreateService = jest
+  .fn()
+  .mockResolvedValue({ terminate: mockIntentCreateServiceTerminate })
+const mockIntentRedirect = jest.fn()
+jest.mock('cozy-interapp', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      createService: mockIntentCreateService,
+      redirect: mockIntentRedirect
+    }
+  })
+})
+
+describe('handleIntent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should call only intents.redirect when we are outside of an Intent', async () => {
+    const client = {}
+    const intentData = undefined
+    const app = {}
+
+    await handleIntent(client, intentData, app)
+    expect(mockIntentRedirect).toHaveBeenCalled()
+    expect(mockIntentCreateService).not.toHaveBeenCalled()
+  })
+  it('should call only intents.createService AND intents.redirect when we are inside of an Intent', async () => {
+    const client = {}
+    const intentData = { data: { slug: 'konnectorSlug' } }
+    const app = {}
+
+    await handleIntent(client, intentData, app)
+    expect(mockIntentCreateService).toHaveBeenCalled()
+    expect(mockIntentRedirect).toHaveBeenCalled()
+    expect(mockIntentCreateServiceTerminate).not.toHaveBeenCalled()
+  })
+  it('should call only intents.createService AND service.terminate when we are inside of an Intent and that we have terminateIfInstalled data option', async () => {
+    const client = {}
+    const intentData = { data: { terminateIfInstalled: true } }
+    const app = {}
+
+    await handleIntent(client, intentData, app)
+    expect(mockIntentCreateService).toHaveBeenCalled()
+    expect(mockIntentCreateServiceTerminate).toHaveBeenCalled()
+    expect(mockIntentRedirect).not.toHaveBeenCalled()
+  })
+})

--- a/src/ducks/apps/components/ApplicationPage/index.jsx
+++ b/src/ducks/apps/components/ApplicationPage/index.jsx
@@ -177,6 +177,7 @@ export class ApplicationPage extends Component {
               name={appName}
               description={appShortDesc}
               parent={parent}
+              intentData={intentData}
             />
             {app.screenshots && !!app.screenshots.length && (
               <Gallery slug={slug} images={app.screenshots} />

--- a/src/ducks/apps/components/Sections/Sections.jsx
+++ b/src/ducks/apps/components/Sections/Sections.jsx
@@ -102,17 +102,6 @@ const Sections = ({
 
   if (error) return <p className="u-error">{error.message}</p>
 
-  const componentsProps = {
-    ...(!!intentData && {
-      appsSection: {
-        disableClick: app => app.installed
-      },
-      searchResults: {
-        disableClick: app => app.installed
-      }
-    })
-  }
-
   return (
     <div className="sto-sections u-mt-2">
       <div className="u-flex u-flex-items-center u-mb-1">
@@ -128,11 +117,7 @@ const Sections = ({
         )}
       </div>
       {searchResults ? (
-        <SearchResults
-          searchResults={searchResults}
-          onAppClick={onAppClick}
-          {...componentsProps?.searchResults}
-        />
+        <SearchResults searchResults={searchResults} onAppClick={onAppClick} />
       ) : (
         <AppSections
           search={filter}
@@ -140,7 +125,6 @@ const Sections = ({
           onSearchChange={handleFilterChange}
           apps={apps}
           onAppClick={onAppClick}
-          componentsProps={componentsProps}
         />
       )}
     </div>

--- a/src/ducks/apps/components/Sections/index.spec.jsx
+++ b/src/ducks/apps/components/Sections/index.spec.jsx
@@ -106,7 +106,7 @@ describe('AppsSection component', () => {
       expect(mockOnAppClick).toBeCalled()
     })
 
-    it("should not call onAppClick when clicking on the app, if it's already installed", () => {
+    it("should call onAppClick when clicking on the app, if it's already installed", () => {
       const trinlaneApp = mockApps.find(app => app.name === 'Trinlane') || {}
       const mockTrinlaneApp = [{ ...trinlaneApp, installed: true }]
       const mockOnAppClick = jest.fn()
@@ -120,7 +120,7 @@ describe('AppsSection component', () => {
 
       expect(() => root.getByText('Trinlane')).not.toThrow()
       fireEvent.click(root.getByText('Trinlane'))
-      expect(mockOnAppClick).not.toBeCalled()
+      expect(mockOnAppClick).toBeCalled()
     })
   })
 })
@@ -167,7 +167,7 @@ describe('Search', () => {
   })
 
   describe('In Intent', () => {
-    it("should not call onAppClick when clicking on the app, if it's already installed", () => {
+    it("should call onAppClick when clicking on the app, if it's already installed", () => {
       const trinlaneApp = mockApps.find(app => app.name === 'Trinlane') || {}
       const mockTrinlaneApp = [{ ...trinlaneApp, installed: true }]
       const mockOnAppClick = jest.fn()
@@ -186,7 +186,7 @@ describe('Search', () => {
       expect(() => root.getByText('Trinlane')).not.toThrow()
 
       fireEvent.click(root.getByText('Trinlane'))
-      expect(mockOnAppClick).not.toBeCalled()
+      expect(mockOnAppClick).toBeCalled()
     })
   })
 })

--- a/src/ducks/search/components.jsx
+++ b/src/ducks/search/components.jsx
@@ -48,7 +48,7 @@ export const SearchField = ({ onChange, value }) => {
   )
 }
 
-export const SearchResults = ({ searchResults, onAppClick, disableClick }) => {
+export const SearchResults = ({ searchResults, onAppClick }) => {
   const sortedSortResults = useMemo(() => {
     return sortBy(searchResults, result => result.score)
   }, [searchResults])
@@ -56,11 +56,10 @@ export const SearchResults = ({ searchResults, onAppClick, disableClick }) => {
     <div className="u-mv-1 u-flex u-flex-wrap">
       {sortedSortResults.map(result => {
         const app = result.item
-        const isDisableClick = disableClick?.(app)
         return flag('store.show-search-score') ? (
           <div>
             <StoreAppItem
-              onClick={() => !isDisableClick && onAppClick(app.slug)}
+              onClick={() => onAppClick(app.slug)}
               key={app.slug}
               app={app}
             />
@@ -73,7 +72,7 @@ export const SearchResults = ({ searchResults, onAppClick, disableClick }) => {
           </div>
         ) : (
           <StoreAppItem
-            onClick={() => !isDisableClick && onAppClick(app.slug)}
+            onClick={() => onAppClick(app.slug)}
             key={app.slug}
             app={app}
           />
@@ -85,6 +84,5 @@ export const SearchResults = ({ searchResults, onAppClick, disableClick }) => {
 
 SearchResults.propTypes = {
   onAppClick: PropTypes.func.isRequired,
-  disableClick: PropTypes.func,
   searchResults: PropTypes.array
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5482,6 +5482,13 @@ cozy-logger@^1.6.0:
     chalk "^2.4.2"
     json-stringify-safe "5.0.1"
 
+cozy-minilog@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/cozy-minilog/-/cozy-minilog-3.3.1.tgz#472dccf4a9391c479120a83d26b435cf9d609c72"
+  integrity sha512-NLQNQ1Q/bvJrqNv9w5bLjfAxYKv+pESobJgUKXondxP616kx7k0mpiRrCZBaJRbEbpKryT/eJ0JJwLdVaIP5NA==
+  dependencies:
+    microee "0.0.6"
+
 cozy-realtime@3.14.4:
   version "3.14.4"
   resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-3.14.4.tgz#fb92d8c39838fa58006e3c6ea5547c445e4bf665"


### PR DESCRIPTION
Added an option to terminate the Intent when you want to "Open" an installed but not connected connector. Necessary because an app like Mespapiers needs to be able to connect a connector already installed.

`disableClick` is no longer useful, because we want to access the details of an already installed connector.

```
### ✨ Features

* Via the Intent, we can access an installed connector page.
  The action of clicking on the "Open" button can close the Intent via the `data={{ terminateIfInstalled: true }}` option of the IntentIframe.
```
