### PR TITLE
feat: Add filter by qualification label for INSTALL intent

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -39,6 +39,7 @@
       "data": [
         "slug",
         "category",
+        "qualificationLabels",
         "pageToDisplay",
         "terminateIfInstalled"
       ],

--- a/src/ducks/apps/components/QuerystringSections.jsx
+++ b/src/ducks/apps/components/QuerystringSections.jsx
@@ -79,7 +79,12 @@ const QuerystringSections = props => {
       return {
         ...filter,
         type: 'konnector',
-        ...(intentData.data?.category && { category: intentData.data.category })
+        ...(intentData.data?.category && {
+          category: intentData.data.category
+        }),
+        ...(intentData.data?.qualificationLabels && {
+          qualificationLabels: intentData.data.qualificationLabels
+        })
       }
     }
     return filter

--- a/src/ducks/components/intents/InstallAppIntent.jsx
+++ b/src/ducks/components/intents/InstallAppIntent.jsx
@@ -114,13 +114,13 @@ export class InstallAppIntent extends Component {
       t
     } = this.props
     const { hasWebappSucceed } = this.state
-    const { category } = data || {}
+    const { category, qualificationLabels } = data || {}
 
     const fetching = isFetching || isAppFetching
     const isReady = !fetchError && !fetching && !isAppFetching
     const isInstalled = app && app.installed
 
-    const appError = isReady && !app && !category
+    const appError = isReady && !app && !category && !qualificationLabels
     const errors = {
       alreadyInstalledError: isInstalled,
       fetchError,

--- a/src/ducks/components/intents/helpers.js
+++ b/src/ducks/components/intents/helpers.js
@@ -1,4 +1,8 @@
 export const isPermissionsPageToDisplay = data => {
-  const { pageToDisplay, category } = data || {}
-  return !category && (!pageToDisplay || pageToDisplay === 'permissions')
+  const { pageToDisplay, category, qualificationLabels } = data || {}
+  return (
+    !category &&
+    !qualificationLabels &&
+    (!pageToDisplay || pageToDisplay === 'permissions')
+  )
 }

--- a/src/ducks/components/intents/helpers.spec.js
+++ b/src/ducks/components/intents/helpers.spec.js
@@ -2,13 +2,19 @@ import { isPermissionsPageToDisplay } from 'ducks/components/intents/helpers'
 
 describe('isPermissionsPageToDisplay', () => {
   it.each`
-    data                                                     | result
-    ${undefined}                                             | ${true}
-    ${{ pageToDisplay: undefined, category: undefined }}     | ${true}
-    ${{ pageToDisplay: 'permissions', category: undefined }} | ${true}
-    ${{ pageToDisplay: undefined, category: 'energy' }}      | ${false}
-    ${{ pageToDisplay: 'details', category: 'energy' }}      | ${false}
-    ${{ pageToDisplay: 'permissions', category: 'energy' }}  | ${false}
+    data                                                                                       | result
+    ${undefined}                                                                               | ${true}
+    ${{ pageToDisplay: undefined, category: undefined, qualificationLabels: undefined }}       | ${true}
+    ${{ pageToDisplay: 'permissions', category: undefined, qualificationLabels: undefined }}   | ${true}
+    ${{ pageToDisplay: undefined, category: 'energy', qualificationLabels: undefined }}        | ${false}
+    ${{ pageToDisplay: 'details', category: 'energy', qualificationLabels: undefined }}        | ${false}
+    ${{ pageToDisplay: 'permissions', category: 'energy', qualificationLabels: undefined }}    | ${false}
+    ${{ pageToDisplay: undefined, category: undefined, qualificationLabels: 'pay_sheet' }}     | ${false}
+    ${{ pageToDisplay: 'details', category: undefined, qualificationLabels: 'pay_sheet' }}     | ${false}
+    ${{ pageToDisplay: 'permissions', category: undefined, qualificationLabels: 'pay_sheet' }} | ${false}
+    ${{ pageToDisplay: undefined, category: 'energy', qualificationLabels: 'pay_sheet' }}      | ${false}
+    ${{ pageToDisplay: 'details', category: 'energy', qualificationLabels: 'pay_sheet' }}      | ${false}
+    ${{ pageToDisplay: 'permissions', category: 'energy', qualificationLabels: 'pay_sheet' }}  | ${false}
   `(`should return $result when passed param: $data`, ({ data, result }) => {
     expect(isPermissionsPageToDisplay(data)).toEqual(result)
   })

--- a/test/components/intents/InstallAppIntentContent.spec.js
+++ b/test/components/intents/InstallAppIntentContent.spec.js
@@ -33,11 +33,12 @@ const AppLike = ({ children } = {}) => {
 const setup = ({
   slug = undefined,
   category = undefined,
+  qualificationLabels = undefined,
   pageToDisplay = undefined,
   isInstalled = false,
   hasWebappSucceed = false
 } = {}) => {
-  const data = { pageToDisplay, category, slug }
+  const data = { pageToDisplay, category, slug, qualificationLabels }
   const props = {
     data,
     isInstalled,
@@ -80,10 +81,11 @@ describe('InstallAppIntentContent component', () => {
   })
 
   describe('App is not installed', () => {
-    it('should be render AppInstallation if "pageToDisplay" & "category" props are falsy', () => {
+    it('should be render AppInstallation if "pageToDisplay", "qualificationLabels" & "category" props are falsy', () => {
       const { getByTestId, queryByTestId } = setup({
         pageToDisplay: undefined,
-        category: undefined
+        category: undefined,
+        qualificationLabels: undefined
       })
       expect(getByTestId('AppInstallation')).toBeInTheDocument()
       expect(queryByTestId('OpenAppsIntentRoutes')).toBeNull()
@@ -93,7 +95,8 @@ describe('InstallAppIntentContent component', () => {
     it('should be render OpenAppsIntentRoutes if "pageToDisplay" prop is defined & not equal to "permissions"', () => {
       const { getByTestId, queryByTestId } = setup({
         pageToDisplay: 'details',
-        category: undefined
+        category: undefined,
+        qualificationLabels: undefined
       })
       expect(getByTestId('OpenAppsIntentRoutes')).toBeInTheDocument()
       expect(queryByTestId('AppInstallation')).toBeNull()
@@ -103,7 +106,8 @@ describe('InstallAppIntentContent component', () => {
     it('should be render OpenAppsIntentRoutes if "category" prop is truthy even if "pageToDisplay" is undefined', () => {
       const { getByTestId, queryByTestId } = setup({
         pageToDisplay: undefined,
-        category: 'energy'
+        category: 'energy',
+        qualificationLabels: undefined
       })
       expect(getByTestId('OpenAppsIntentRoutes')).toBeInTheDocument()
       expect(queryByTestId('AppInstallation')).toBeNull()
@@ -113,7 +117,52 @@ describe('InstallAppIntentContent component', () => {
     it('should be render OpenAppsIntentRoutes if "category" prop is truthy even if "pageToDisplay" is et to "permission"', () => {
       const { getByTestId, queryByTestId } = setup({
         pageToDisplay: 'permissions',
-        category: 'energy'
+        category: 'energy',
+        qualificationLabels: undefined
+      })
+      expect(getByTestId('OpenAppsIntentRoutes')).toBeInTheDocument()
+      expect(queryByTestId('AppInstallation')).toBeNull()
+      expect(queryByTestId('InstallSuccess')).toBeNull()
+    })
+
+    it('should be render OpenAppsIntentRoutes if "category" & "qualificationLabels" props are truthy even if "pageToDisplay" is undefined', () => {
+      const { getByTestId, queryByTestId } = setup({
+        pageToDisplay: undefined,
+        category: 'energy',
+        qualificationLabels: 'pay_sheet'
+      })
+      expect(getByTestId('OpenAppsIntentRoutes')).toBeInTheDocument()
+      expect(queryByTestId('AppInstallation')).toBeNull()
+      expect(queryByTestId('InstallSuccess')).toBeNull()
+    })
+
+    it('should be render OpenAppsIntentRoutes if "category" & "qualificationLabels" props are truthy even if "pageToDisplay" is et to "permission"', () => {
+      const { getByTestId, queryByTestId } = setup({
+        pageToDisplay: 'permissions',
+        category: 'energy',
+        qualificationLabels: 'pay_sheet'
+      })
+      expect(getByTestId('OpenAppsIntentRoutes')).toBeInTheDocument()
+      expect(queryByTestId('AppInstallation')).toBeNull()
+      expect(queryByTestId('InstallSuccess')).toBeNull()
+    })
+
+    it('should be render OpenAppsIntentRoutes if "qualificationLabels" prop is truthy even if "pageToDisplay" is undefined', () => {
+      const { getByTestId, queryByTestId } = setup({
+        pageToDisplay: undefined,
+        category: undefined,
+        qualificationLabels: 'pay_sheet'
+      })
+      expect(getByTestId('OpenAppsIntentRoutes')).toBeInTheDocument()
+      expect(queryByTestId('AppInstallation')).toBeNull()
+      expect(queryByTestId('InstallSuccess')).toBeNull()
+    })
+
+    it('should be render OpenAppsIntentRoutes if "qualificationLabels" prop is truthy even if "pageToDisplay" is et to "permission"', () => {
+      const { getByTestId, queryByTestId } = setup({
+        pageToDisplay: 'permissions',
+        category: undefined,
+        qualificationLabels: 'pay_sheet'
       })
       expect(getByTestId('OpenAppsIntentRoutes')).toBeInTheDocument()
       expect(queryByTestId('AppInstallation')).toBeNull()


### PR DESCRIPTION
Just like `category` or in addition, `qualificationLabels` allows you to filter the list of Store applications based on their qualification label.

```
### ✨ Features

* Add filter by qualification label for INSTALL intent
```
