### PR TITLE
[SCR-785] typo: Replace commercial & by appropriate equivalents

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -154,8 +154,8 @@
     "telecom": "Telecom",
     "transport": "Transportation",
     "tech": "Tech",
-    "clouds": "Clouds & digitale schließfächer",
-    "finance": "Beschäftigung & finanzen"
+    "clouds": "Clouds und digitale schließfächer",
+    "finance": "Beschäftigung und finanzen"
   },
 
   "app_langs": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -163,8 +163,8 @@
     "transport": "Transportation",
     "pro": "Work",
     "tech": "Tech",
-    "clouds": "Clouds & vaults",
-    "finance": "Employment & finance"
+    "clouds": "Clouds and vaults",
+    "finance": "Employment and finance"
   },
 
   "app_langs": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -163,8 +163,8 @@
     "transport": "Voyage et transport",
     "pro": "Travail",
     "tech": "Tech",
-    "clouds": "Clouds & coffres",
-    "finance": "Emploi & finance"
+    "clouds": "Clouds et coffres",
+    "finance": "Emploi et finance"
   },
 
   "app_langs": {

--- a/src/locales/nl_NL.json
+++ b/src/locales/nl_NL.json
@@ -163,8 +163,8 @@
     "transport": "Vervoer",
     "pro": "Werk",
     "tech": "Tech",
-    "clouds": "Wolken & digitale gewelven",
-    "finance": "Werkgelegenheid & financiën"
+    "clouds": "Wolken en digitale gewelven",
+    "finance": "Werkgelegenheid en financiën"
   },
 
   "app_langs": {

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -155,8 +155,8 @@
     "telecom": "Telecom",
     "transport": "Transportation",
     "tech": "Tech",
-    "clouds": "Clouds & vaults",
-    "finance": "Employment & finance"
+    "clouds": "Clouds and vaults",
+    "finance": "Employment and finance"
   },
 
   "app_langs": {


### PR DESCRIPTION

```

### 🐛 Bug Fixes

* Replace "&" char by their equivalent in each language to uniformize display in store

```

PR for cozy-ui incoming 🙏 