### PR TITLE
[PRD-538] feat: Hide dataproxy app

### DIFF
--- a/src/config/apps.json
+++ b/src/config/apps.json
@@ -1,4 +1,4 @@
 {
   "notRemovableApps": ["drive"],
-  "notDisplayedApps": ["collect", "home", "settings", "store"]
+  "notDisplayedApps": ["collect", "home", "settings", "store", "dataproxy"]
 }


### PR DESCRIPTION
We introduced a "fake" app, the dataproxy, that is meant to be a core component to handle data and notably to persist it locally, but should not be displayed.



```
### ✨ Features

* Hide dataproxy app

### 🐛 Bug Fixes

*

### 🔧 Tech

*
```
