### PR TITLE
[PRD-538] feat: Upgrade cozy-bar for new flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@cozy/minilog": "^1.0.0",
     "@sentry/integrations": "^7.114.0",
     "@sentry/react": "^8.5.0",
-    "cozy-bar": "^15.0.0",
+    "cozy-bar": "15.1.0",
     "cozy-client": "^49.4.0",
     "cozy-device-helper": "^2.1.0",
     "cozy-doctypes": "1.85.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5419,10 +5419,10 @@ cozy-app-publish@^0.27.2:
     request "^2.88.0"
     tar "^4.4.13"
 
-cozy-bar@^15.0.0:
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-bar/-/cozy-bar-15.0.0.tgz#781d07c1ac759b57cebb8af8d64b8f8ab425706a"
-  integrity sha512-T5D2Me0gmp4SDMvDBfR7V3E1IYAo1Adby7jUr9bk+aouyte4uz+KnAyEdgp6VXWBnbfUvAfqwBpTdwDzjaHXvQ==
+cozy-bar@15.1.0:
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-bar/-/cozy-bar-15.1.0.tgz#f7f624130d1b56539b05e4a02df520b245788b6f"
+  integrity sha512-Nx9B/cD7upmBisFGOu5V7nr5zgJfCiwRA3ChaAnF2ifC6p1HiwhbvJCXMW7VpX0dDZNVmM7VWXGnvDaw+VinTg==
   dependencies:
     hammerjs "2.0.8"
     lodash.debounce "4.0.8"


### PR DESCRIPTION
Benefit from the new apps.hidden flag, to hide apps in the bar menu. This is typically done to hide the new dataproxy app used for search.



```
### ✨ Features

* Upgrade cozy-bar to hide apps from flag

### 🐛 Bug Fixes

*

### 🔧 Tech

*
```
