### PR TITLE
fix: Downgrade cozy-dataproxy-lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@sentry/react": "^8.5.0",
     "cozy-bar": "^22.1.1",
     "cozy-client": "^57.7.2",
-    "cozy-dataproxy-lib": "^4.5.0",
+    "cozy-dataproxy-lib": "4.1.0",
     "cozy-device-helper": "^3.8.0",
     "cozy-devtools": "^1.3.0",
     "cozy-doctypes": "^1.97.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4708,10 +4708,10 @@ cozy-client@^57.7.2:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-dataproxy-lib@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/cozy-dataproxy-lib/-/cozy-dataproxy-lib-4.5.0.tgz#fc3616f9185727f2c9ee425fa2c10dd6889ae0d2"
-  integrity sha512-zk70SeTLh798QfOkWEajOGmKGgo5V1Zbvdf9FA0T8mw17qjyxU2qYTRYTZbd4ZTCfKvp8dw1+RkzPzcUvkoBiQ==
+cozy-dataproxy-lib@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-dataproxy-lib/-/cozy-dataproxy-lib-4.1.0.tgz#20d0a38e059fb5924d85f3b5a550d7d28ec9a477"
+  integrity sha512-k5lVjnpPmATEUZaYeK0B8J0+ntiNRmpmTXyDi8p6H7y41LO/yZ0XhbIqxbO4PjPnT8aKFWx3zQ7LGqIXS2Y7LA==
   dependencies:
     comlink "4.4.1"
     flexsearch "0.7.43"


### PR DESCRIPTION
cozy-dataproxy-lib >= 4.2.0 is not working with flagship app. We need to find a fix but as we want to release apps now, lets downgrade.